### PR TITLE
fix(splash): streamline splash navigation and app update exit logic

### DIFF
--- a/data/app-updates/src/main/kotlin/com/flixclusive/data/app/updates/repository/impl/GithubUpdatesRepository.kt
+++ b/data/app-updates/src/main/kotlin/com/flixclusive/data/app/updates/repository/impl/GithubUpdatesRepository.kt
@@ -30,7 +30,8 @@ internal class GithubUpdatesRepository @Inject constructor(
         val buildConfig = buildConfigProvider.get()
 
         val repository = when (buildConfig.buildType) {
-            BuildType.PREVIEW, BuildType.DEBUG -> PREVIEW_CHANNEL_NAME
+            BuildType.DEBUG -> return Result.success(null)
+            BuildType.PREVIEW -> PREVIEW_CHANNEL_NAME
             else -> STABLE_CHANNEL_NAME
         }
 

--- a/feature/mobile/app-updates/src/main/kotlin/com/flixclusive/feature/mobile/app/updates/screen/AppUpdatesScreen.kt
+++ b/feature/mobile/app-updates/src/main/kotlin/com/flixclusive/feature/mobile/app/updates/screen/AppUpdatesScreen.kt
@@ -95,24 +95,31 @@ internal fun AppUpdatesScreen(
     val lifecycleOwner = LocalLifecycleOwner.current
     val downloadState by viewModel.downloadState.collectAsStateWithLifecycle()
 
+    val goBack = fun() {
+        val isResumed = lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
+        if (!isResumed) return
+
+        if (isComingFromSplashScreen) {
+            navigator.navigateToHomeScreen()
+        } else {
+            navigator.navigateBack()
+        }
+    }
+
+    BackHandler(onBack = goBack)
+
     AppUpdatesScreenContent(
         applicationId = viewModel.applicationId,
         newVersion = newVersion,
         updateInfo = updateInfo,
-        isComingFromSplashScreen = isComingFromSplashScreen,
         downloadState = downloadState,
+        goBack = goBack,
         downloadUpdate = {
             viewModel.downloadUpdate(
                 version = newVersion,
                 url = updateUrl,
             )
         },
-        openHomeScreen = {
-            if (lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
-                navigator.navigateToHomeScreen()
-            }
-        },
-        goBack = navigator::navigateBack,
     )
 }
 
@@ -121,10 +128,8 @@ private fun AppUpdatesScreenContent(
     applicationId: String,
     newVersion: String,
     updateInfo: String?,
-    isComingFromSplashScreen: Boolean,
     downloadState: DownloadState,
     downloadUpdate: () -> Unit,
-    openHomeScreen: () -> Unit,
     goBack: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -151,15 +156,11 @@ private fun AppUpdatesScreenContent(
         )
 
         context.startActivity(createApkInstallIntent(uri))
-        openHomeScreen()
+        goBack()
     }
 
     BackHandler {
-        if (isComingFromSplashScreen) {
-            openHomeScreen()
-        } else {
-            goBack()
-        }
+        goBack()
     }
 
     Box(
@@ -268,13 +269,7 @@ private fun AppUpdatesScreenContent(
                     }
 
                     Button(
-                        onClick = {
-                            if (isComingFromSplashScreen) {
-                                openHomeScreen()
-                            } else {
-                                goBack()
-                            }
-                        },
+                        onClick = goBack,
                         colors = ButtonDefaults.buttonColors(
                             containerColor = MaterialTheme.colorScheme.surfaceVariant,
                             contentColor = Color.White.copy(0.6f),
@@ -398,7 +393,6 @@ private fun AppUpdatesScreenBasePreview() {
 
                     For more details, visit our [website](https://example.com).
                 """.trimIndent(),
-                isComingFromSplashScreen = false,
                 downloadState = state,
                 downloadUpdate = {
                     state = state.copy(
@@ -407,7 +401,6 @@ private fun AppUpdatesScreenBasePreview() {
                         progress = 0f,
                     )
                 },
-                openHomeScreen = {},
                 goBack = {},
             )
         }

--- a/feature/splash-screen/src/main/kotlin/com/flixclusive/feature/splashScreen/SplashScreenViewModel.kt
+++ b/feature/splash-screen/src/main/kotlin/com/flixclusive/feature/splashScreen/SplashScreenViewModel.kt
@@ -130,10 +130,10 @@ internal class SplashScreenViewModel @Inject constructor(
         val updateInfo = snapshot.uiState.newAppUpdateInfo
 
         return when {
-            updateInfo != null && hasAutoUpdate -> SplashNavigationEvent.AppUpdate(updateInfo)
             snapshot.preferences.isFirstTimeUserLaunch -> SplashNavigationEvent.Onboarding
-            snapshot.noUsersFound -> SplashNavigationEvent.AddProfile
             snapshot.currentUserId == null -> SplashNavigationEvent.ChooseProfile
+            snapshot.noUsersFound -> SplashNavigationEvent.AddProfile
+            updateInfo != null && hasAutoUpdate -> SplashNavigationEvent.AppUpdate(updateInfo)
             else -> SplashNavigationEvent.Home
         }
     }


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue. Explain the motivation for the change.

Fixes:
- app updates crashes app for new non-onboarded users
- app updates failing due to incorrect mapping for the wrong APK file

## Checklist

- [x] I have followed the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for all my commits.
    - Example of a Conventional Commit message: `feat: add new feature to enhance user experience`
