### PR TITLE
refactor(provider): migrate debug providers

### DIFF
--- a/core/common/src/main/kotlin/com/flixclusive/core/common/provider/ProviderFile.kt
+++ b/core/common/src/main/kotlin/com/flixclusive/core/common/provider/ProviderFile.kt
@@ -1,6 +1,7 @@
 package com.flixclusive.core.common.provider
 
 import android.content.Context
+import android.os.Environment
 import com.flixclusive.core.common.provider.ProviderConstants.PROVIDERS_FOLDER_NAME
 import com.flixclusive.core.common.provider.ProviderConstants.PROVIDERS_SETTINGS_FOLDER_NAME
 import com.flixclusive.core.common.provider.ProviderConstants.PROVIDER_DEBUG
@@ -24,6 +25,9 @@ object ProviderFile {
     fun Context.getProvidersSettingsPath(userId: String): String =
         getExternalFilesDir(null)?.absolutePath + "/$PROVIDERS_SETTINGS_FOLDER_NAME/user-$userId"
 
-    fun Context.getDebugProvidersPath(): String =
-        getExternalFilesDir(null)?.absolutePath + "/$PROVIDERS_FOLDER_NAME/$PROVIDER_DEBUG"
+    fun getDebugProvidersPath(): String =
+        "${Environment.getExternalStorageDirectory().absolutePath}/Flixclusive/$PROVIDERS_FOLDER_NAME/$PROVIDER_DEBUG"
+
+    fun getDebugProvidersSettingsPath(): String =
+        "${Environment.getExternalStorageDirectory().absolutePath}/Flixclusive/$PROVIDERS_SETTINGS_FOLDER_NAME/$PROVIDER_DEBUG"
 }

--- a/core/presentation/mobile/src/main/kotlin/com/flixclusive/core/presentation/mobile/components/provider/ProviderCrashBottomSheet.kt
+++ b/core/presentation/mobile/src/main/kotlin/com/flixclusive/core/presentation/mobile/components/provider/ProviderCrashBottomSheet.kt
@@ -199,7 +199,7 @@ private fun CrashItem(
             error = remember {
                 var message: String? = null
                 if (error is ExceptionWithUiText) {
-                    message = error.cause?.stackTraceToString() ?: error.uiText?.asString(resources)
+                    message = error.uiText?.asString(resources) ?: error.cause?.stackTraceToString()
                 }
 
                 message ?: error.stackTraceToString()

--- a/core/presentation/mobile/src/main/kotlin/com/flixclusive/core/presentation/mobile/components/provider/ProviderCrashDialog.kt
+++ b/core/presentation/mobile/src/main/kotlin/com/flixclusive/core/presentation/mobile/components/provider/ProviderCrashDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -30,6 +31,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.flixclusive.core.common.exception.ExceptionWithUiText
 import com.flixclusive.core.presentation.common.util.DummyDataForPreview
 import com.flixclusive.core.presentation.mobile.R
 import com.flixclusive.core.presentation.mobile.components.material3.dialog.CommonAlertDialog
@@ -45,9 +47,17 @@ internal fun ProviderCrashDialog(
     error: Throwable,
     onDismissRequest: () -> Unit,
 ) {
+    val resources = LocalResources.current
     val uriHandler = LocalUriHandler.current
 
-    val stackTrace = remember { error.stackTraceToString() }
+    val stackTrace = remember {
+        if (error is ExceptionWithUiText) {
+            Error(error.uiText?.asString(resources) ?: error.localizedMessage)
+                .stackTraceToString()
+        } else {
+            error.stackTraceToString()
+        }
+    }
 
     CommonAlertDialog(
         onDismiss = onDismissRequest,

--- a/data/backup/src/main/kotlin/com/flixclusive/data/backup/restore/impl/ProviderBackupRestorer.kt
+++ b/data/backup/src/main/kotlin/com/flixclusive/data/backup/restore/impl/ProviderBackupRestorer.kt
@@ -2,7 +2,7 @@ package com.flixclusive.data.backup.restore.impl
 
 import android.content.Context
 import com.flixclusive.core.common.provider.ProviderConstants
-import com.flixclusive.core.common.provider.ProviderFile.getDebugProvidersPath
+import com.flixclusive.core.common.provider.ProviderFile
 import com.flixclusive.core.common.provider.ProviderFile.getProvidersPath
 import com.flixclusive.core.database.dao.provider.InstalledProviderDao
 import com.flixclusive.core.database.entity.provider.InstalledProvider
@@ -64,7 +64,7 @@ internal class ProviderBackupRestorer @Inject constructor(
             includeDebugSuffixMapping = false,
         )
 
-        val debugPath = context.getDebugProvidersPath()
+        val debugPath = ProviderFile.getDebugProvidersPath()
         indexProvidersInRoot(
             index = index,
             root = File(debugPath),

--- a/domain/provider/src/main/kotlin/com/flixclusive/domain/provider/usecase/manage/impl/InitializeProvidersUseCaseImpl.kt
+++ b/domain/provider/src/main/kotlin/com/flixclusive/domain/provider/usecase/manage/impl/InitializeProvidersUseCaseImpl.kt
@@ -3,9 +3,9 @@ package com.flixclusive.domain.provider.usecase.manage.impl
 import android.content.Context
 import com.flixclusive.core.common.dispatchers.AppDispatchers
 import com.flixclusive.core.common.provider.ProviderConstants
+import com.flixclusive.core.common.provider.ProviderFile
 import com.flixclusive.core.database.entity.provider.InstalledProvider
 import com.flixclusive.core.datastore.DataStoreManager
-import com.flixclusive.core.datastore.PROVIDERS_FOLDER_NAME
 import com.flixclusive.core.datastore.UserSessionDataStore
 import com.flixclusive.core.datastore.model.user.ProviderPreferences
 import com.flixclusive.core.datastore.model.user.UserPreferences
@@ -91,7 +91,7 @@ internal class InitializeProvidersUseCaseImpl @Inject constructor(
      * them to the preferences, if they are not already present.
      * */
     private suspend fun initializeDebugProviders(userId: String) {
-        val path = "${context.getExternalFilesDir(null)}/$PROVIDERS_FOLDER_NAME/debug"
+        val path = ProviderFile.getDebugProvidersPath()
         val localDir = File(path)
 
         if (!localDir.exists()) {

--- a/domain/provider/src/main/kotlin/com/flixclusive/domain/provider/usecase/manage/impl/LoadProviderUseCaseImpl.kt
+++ b/domain/provider/src/main/kotlin/com/flixclusive/domain/provider/usecase/manage/impl/LoadProviderUseCaseImpl.kt
@@ -6,8 +6,9 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import com.flixclusive.core.common.dispatchers.AppDispatchers
 import com.flixclusive.core.common.provider.ProviderConstants
+import com.flixclusive.core.common.provider.ProviderFile
+import com.flixclusive.core.common.provider.ProviderFile.getProvidersSettingsPath
 import com.flixclusive.core.database.entity.provider.InstalledProvider
-import com.flixclusive.core.datastore.PROVIDERS_SETTINGS_FOLDER_NAME
 import com.flixclusive.core.datastore.UserSessionDataStore
 import com.flixclusive.core.datastore.model.user.ProviderPreferences
 import com.flixclusive.core.util.log.errorLog
@@ -254,12 +255,13 @@ internal class LoadProviderUseCaseImpl @Inject constructor(
         repositoryUrl: String,
         isDebugProvider: Boolean,
     ): String {
-        val parentDirectoryName = if (isDebugProvider) ProviderConstants.PROVIDER_DEBUG else "user-$userId"
-
         val repository = repositoryUrl.toValidRepositoryLink()
         val childDirectoryName = "${repository.owner}-${repository.name}"
-        val finalPathPrefix = "$PROVIDERS_SETTINGS_FOLDER_NAME/$parentDirectoryName/$childDirectoryName"
 
-        return "${context.getExternalFilesDir(null)}/$finalPathPrefix"
+        return if (isDebugProvider) {
+            ProviderFile.getDebugProvidersSettingsPath() + "/$childDirectoryName"
+        } else {
+            context.getProvidersSettingsPath(userId) + "/$childDirectoryName"
+        }
     }
 }

--- a/feature/mobile/onboarding/src/main/kotlin/com/flixclusive/feature/mobile/onboarding/OnboardingScreen.kt
+++ b/feature/mobile/onboarding/src/main/kotlin/com/flixclusive/feature/mobile/onboarding/OnboardingScreen.kt
@@ -4,11 +4,8 @@ package com.flixclusive.feature.mobile.onboarding
 
 import android.Manifest
 import android.annotation.SuppressLint
-import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.os.Build
-import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
@@ -50,7 +47,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -86,11 +82,12 @@ internal fun OnboardingScreen(
         }
     }
 
-    var notificationsGranted by remember { mutableStateOf(isNotificationsGranted(context)) }
-    var unknownSourcesAllowed by remember { mutableStateOf(isUnknownSourcesAllowed(context)) }
+    var notificationsGranted by remember { mutableStateOf(PermissionUtil.isNotificationsGranted(context)) }
+    var storageAccessGranted by remember { mutableStateOf(PermissionUtil.isStorageAccessGranted(context)) }
+    var unknownSourcesAllowed by remember { mutableStateOf(PermissionUtil.isUnknownSourcesAllowed(context)) }
 
     val grantedPermissions = remember(context) {
-        getPreGrantedPermissions(
+        PermissionUtil.getPreGrantedPermissions(
             context = context,
             excludedPermissions = mutableSetOf(
                 Manifest.permission.REQUEST_INSTALL_PACKAGES,
@@ -108,10 +105,24 @@ internal fun OnboardingScreen(
         notificationsGranted = granted
     }
 
+    val manageStorageSettingsLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) {
+        storageAccessGranted = PermissionUtil.isStorageAccessGranted(context)
+    }
+
+    val storageAccessPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions(),
+    ) { granted ->
+        val isWritingGranted = granted[Manifest.permission.WRITE_EXTERNAL_STORAGE] ?: false
+        val isReadingGranted = granted[Manifest.permission.READ_EXTERNAL_STORAGE] ?: false
+        storageAccessGranted = isWritingGranted && isReadingGranted
+    }
+
     val unknownSourcesSettingsLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult(),
     ) {
-        unknownSourcesAllowed = isUnknownSourcesAllowed(context)
+        unknownSourcesAllowed = PermissionUtil.isUnknownSourcesAllowed(context)
     }
 
     val storageDirectoryPicker = rememberLauncherForActivityResult(
@@ -128,8 +139,9 @@ internal fun OnboardingScreen(
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
-                notificationsGranted = isNotificationsGranted(context)
-                unknownSourcesAllowed = isUnknownSourcesAllowed(context)
+                notificationsGranted = PermissionUtil.isNotificationsGranted(context)
+                unknownSourcesAllowed = PermissionUtil.isUnknownSourcesAllowed(context)
+                storageAccessGranted = PermissionUtil.isStorageAccessGranted(context)
             }
         }
 
@@ -148,19 +160,35 @@ internal fun OnboardingScreen(
 
     OnboardingScreenContent(
         notificationsGranted = notificationsGranted,
+        storageAccessGranted = storageAccessGranted,
         unknownSourcesAllowed = unknownSourcesAllowed,
         storageDirectoryUri = filePath,
         grantedPermissions = grantedPermissions,
+        finishOnboarding = viewModel::completeOnboarding,
+        openUnknownSourcesSettings = {
+            unknownSourcesSettingsLauncher.launch(PermissionUtil.createUnknownSourcesIntent(context.packageName))
+        },
+        openStorageDirectoryPicker = { storageDirectoryPicker.launch(null) },
         requestNotificationsPermission = {
             if (Build.VERSION.SDK_INT >= 33) {
                 notificationsPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
             }
         },
-        openUnknownSourcesSettings = {
-            unknownSourcesSettingsLauncher.launch(createUnknownSourcesIntent(context.packageName))
+        requestStorageAccess = {
+            when {
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> {
+                    manageStorageSettingsLauncher.launch(PermissionUtil.createManageStorageIntent(context))
+                }
+                else -> {
+                    storageAccessPermissionLauncher.launch(
+                        arrayOf(
+                            Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                            Manifest.permission.READ_EXTERNAL_STORAGE,
+                        ),
+                    )
+                }
+            }
         },
-        openStorageDirectoryPicker = { storageDirectoryPicker.launch(null) },
-        finishOnboarding = viewModel::completeOnboarding,
     )
 }
 
@@ -168,10 +196,12 @@ internal fun OnboardingScreen(
 @Composable
 private fun OnboardingScreenContent(
     notificationsGranted: Boolean,
+    storageAccessGranted: Boolean,
     unknownSourcesAllowed: Boolean,
     storageDirectoryUri: String?,
     grantedPermissions: List<GrantedPermissionItem>,
     requestNotificationsPermission: () -> Unit,
+    requestStorageAccess: () -> Unit,
     openUnknownSourcesSettings: () -> Unit,
     openStorageDirectoryPicker: () -> Unit,
     finishOnboarding: () -> Unit,
@@ -256,7 +286,9 @@ private fun OnboardingScreenContent(
                     OnboardingStep.Permissions -> PermissionsStep(
                         notificationsGranted = notificationsGranted,
                         unknownSourcesAllowed = unknownSourcesAllowed,
+                        storageAccessGranted = storageAccessGranted,
                         grantedPermissions = grantedPermissions,
+                        requestStorageAccess = requestStorageAccess,
                         requestNotificationsPermission = requestNotificationsPermission,
                         openUnknownSourcesSettings = openUnknownSourcesSettings,
                     )
@@ -341,101 +373,6 @@ private enum class OnboardingStep {
     FinishUp,
 }
 
-private fun isNotificationsGranted(context: Context): Boolean {
-    return when {
-        Build.VERSION.SDK_INT < 33 -> true
-
-        else -> ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.POST_NOTIFICATIONS,
-        ) == PackageManager.PERMISSION_GRANTED
-    }
-}
-
-@Suppress("DEPRECATION")
-private fun isUnknownSourcesAllowed(context: Context): Boolean {
-    return when {
-        Build.VERSION.SDK_INT >= 26 -> {
-            context.packageManager.canRequestPackageInstalls()
-        }
-
-        else -> {
-            runCatching {
-                Settings.Secure.getInt(
-                    context.contentResolver,
-                    Settings.Secure.INSTALL_NON_MARKET_APPS,
-                    0,
-                ) == 1
-            }.getOrDefault(true)
-        }
-    }
-}
-
-private fun getPreGrantedPermissions(
-    context: Context,
-    excludedPermissions: Set<String>,
-): List<GrantedPermissionItem> {
-    val pm = context.packageManager
-
-    val requestedPermissions = runCatching {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            pm
-                .getPackageInfo(
-                    context.packageName,
-                    PackageManager.PackageInfoFlags.of(PackageManager.GET_PERMISSIONS.toLong()),
-                ).requestedPermissions
-        } else {
-            @Suppress("DEPRECATION")
-            pm.getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS).requestedPermissions
-        }
-    }.getOrNull().orEmpty().toList()
-
-    return requestedPermissions
-        .asSequence()
-        .filterNot { it in excludedPermissions }
-        .filter { permission ->
-            ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
-        }.distinct()
-        .mapNotNull { permission ->
-            val label = runCatching {
-                pm
-                    .getPermissionInfo(permission, 0)
-                    .loadLabel(pm)
-                    .toString()
-            }.getOrNull().orEmpty()
-
-            val description = runCatching {
-                pm
-                    .getPermissionInfo(permission, 0)
-                    .loadDescription(pm)
-                    .toString()
-            }.getOrNull().orEmpty()
-
-            if (label.isEmpty()) return@mapNotNull null
-            if (label.startsWith("com.")) return@mapNotNull null
-
-            GrantedPermissionItem(
-                label = label
-                    .ifBlank { permission.substringAfterLast('.') }
-                    .replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },
-                description = description
-                    .replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },
-            )
-        }.sortedBy { it.label.lowercase() }
-        .toList()
-}
-
-private fun createUnknownSourcesIntent(packageName: String): Intent {
-    return when {
-        Build.VERSION.SDK_INT >= 26 -> Intent(
-            Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
-            "package:$packageName".toUri(),
-        )
-
-        else -> Intent(Settings.ACTION_SECURITY_SETTINGS)
-    }
-}
-
 @Preview
 @Composable
 private fun OnboardingScreenBasePreview() {
@@ -446,6 +383,7 @@ private fun OnboardingScreenBasePreview() {
             OnboardingScreenContent(
                 notificationsGranted = false,
                 unknownSourcesAllowed = false,
+                storageAccessGranted = false,
                 storageDirectoryUri = null,
                 grantedPermissions = listOf(
                     GrantedPermissionItem(
@@ -458,6 +396,7 @@ private fun OnboardingScreenBasePreview() {
                     ),
                 ),
                 requestNotificationsPermission = {},
+                requestStorageAccess = {},
                 openUnknownSourcesSettings = {},
                 openStorageDirectoryPicker = {},
                 finishOnboarding = {},
@@ -506,6 +445,7 @@ private fun OnboardingScreenPermissionsStepPreview() {
             OnboardingScreenContent(
                 notificationsGranted = false,
                 unknownSourcesAllowed = false,
+                storageAccessGranted = false,
                 storageDirectoryUri = null,
                 grantedPermissions = listOf(
                     GrantedPermissionItem(
@@ -514,6 +454,7 @@ private fun OnboardingScreenPermissionsStepPreview() {
                     ),
                 ),
                 requestNotificationsPermission = {},
+                requestStorageAccess = {},
                 openUnknownSourcesSettings = {},
                 openStorageDirectoryPicker = {},
                 finishOnboarding = {},
@@ -533,8 +474,10 @@ private fun OnboardingScreenStorageStepPreview() {
             OnboardingScreenContent(
                 notificationsGranted = true,
                 unknownSourcesAllowed = true,
+                storageAccessGranted = true,
                 storageDirectoryUri = null,
                 grantedPermissions = emptyList(),
+                requestStorageAccess = {},
                 requestNotificationsPermission = {},
                 openUnknownSourcesSettings = {},
                 openStorageDirectoryPicker = {},
@@ -555,8 +498,10 @@ private fun OnboardingScreenNextStepsStepPreview() {
             OnboardingScreenContent(
                 notificationsGranted = true,
                 unknownSourcesAllowed = true,
+                storageAccessGranted = true,
                 storageDirectoryUri = "content://com.android.externalstorage.documents/tree/primary%3AFlixclusive",
                 grantedPermissions = emptyList(),
+                requestStorageAccess = {},
                 requestNotificationsPermission = {},
                 openUnknownSourcesSettings = {},
                 openStorageDirectoryPicker = {},

--- a/feature/mobile/onboarding/src/main/kotlin/com/flixclusive/feature/mobile/onboarding/PermissionUtil.kt
+++ b/feature/mobile/onboarding/src/main/kotlin/com/flixclusive/feature/mobile/onboarding/PermissionUtil.kt
@@ -13,7 +13,6 @@ import androidx.core.net.toUri
 import com.flixclusive.feature.mobile.onboarding.component.GrantedPermissionItem
 
 internal object PermissionUtil {
-
     @RequiresApi(Build.VERSION_CODES.R)
     fun createManageStorageIntent(context: Context): Intent {
         return try {
@@ -32,10 +31,12 @@ internal object PermissionUtil {
                 Environment.isExternalStorageManager()
             }
 
-            else -> ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE,
-            ) == PackageManager.PERMISSION_GRANTED
+            else -> {
+                ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                ) == PackageManager.PERMISSION_GRANTED
+            }
         }
     }
 

--- a/feature/mobile/onboarding/src/main/kotlin/com/flixclusive/feature/mobile/onboarding/PermissionUtil.kt
+++ b/feature/mobile/onboarding/src/main/kotlin/com/flixclusive/feature/mobile/onboarding/PermissionUtil.kt
@@ -1,0 +1,136 @@
+package com.flixclusive.feature.mobile.onboarding
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Environment
+import android.provider.Settings
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
+import com.flixclusive.feature.mobile.onboarding.component.GrantedPermissionItem
+
+internal object PermissionUtil {
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    fun createManageStorageIntent(context: Context): Intent {
+        return try {
+            Intent(
+                Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+                "package:${context.packageName}".toUri(),
+            )
+        } catch (_: Exception) {
+            Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
+        }
+    }
+
+    fun isStorageAccessGranted(context: Context): Boolean {
+        return when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> {
+                Environment.isExternalStorageManager()
+            }
+
+            else -> ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            ) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    fun isNotificationsGranted(context: Context): Boolean {
+        return when {
+            Build.VERSION.SDK_INT < 33 -> true
+
+            else -> ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    fun isUnknownSourcesAllowed(context: Context): Boolean {
+        return when {
+            Build.VERSION.SDK_INT >= 26 -> {
+                context.packageManager.canRequestPackageInstalls()
+            }
+
+            else -> {
+                runCatching {
+                    Settings.Secure.getInt(
+                        context.contentResolver,
+                        Settings.Secure.INSTALL_NON_MARKET_APPS,
+                        0,
+                    ) == 1
+                }.getOrDefault(true)
+            }
+        }
+    }
+
+    fun getPreGrantedPermissions(
+        context: Context,
+        excludedPermissions: Set<String>,
+    ): List<GrantedPermissionItem> {
+        val pm = context.packageManager
+
+        val requestedPermissions = runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                pm
+                    .getPackageInfo(
+                        context.packageName,
+                        PackageManager.PackageInfoFlags.of(PackageManager.GET_PERMISSIONS.toLong()),
+                    ).requestedPermissions
+            } else {
+                @Suppress("DEPRECATION")
+                pm.getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS).requestedPermissions
+            }
+        }.getOrNull().orEmpty().toList()
+
+        return requestedPermissions
+            .asSequence()
+            .filterNot { it in excludedPermissions }
+            .filter { permission ->
+                ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+            }.distinct()
+            .mapNotNull { permission ->
+                val label = runCatching {
+                    pm
+                        .getPermissionInfo(permission, 0)
+                        .loadLabel(pm)
+                        .toString()
+                }.getOrNull().orEmpty()
+
+                val description = runCatching {
+                    pm
+                        .getPermissionInfo(permission, 0)
+                        .loadDescription(pm)
+                        .toString()
+                }.getOrNull().orEmpty()
+
+                if (label.isEmpty()) return@mapNotNull null
+                if (label.startsWith("com.")) return@mapNotNull null
+
+                GrantedPermissionItem(
+                    label = label
+                        .ifBlank { permission.substringAfterLast('.') }
+                        .replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },
+                    description = description
+                        .replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },
+                )
+            }.sortedBy { it.label.lowercase() }
+            .toList()
+    }
+
+    fun createUnknownSourcesIntent(packageName: String): Intent {
+        return when {
+            Build.VERSION.SDK_INT >= 26 -> Intent(
+                Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                "package:$packageName".toUri(),
+            )
+
+            else -> Intent(Settings.ACTION_SECURITY_SETTINGS)
+        }
+    }
+}

--- a/feature/mobile/onboarding/src/main/kotlin/com/flixclusive/feature/mobile/onboarding/component/PermissionsStep.kt
+++ b/feature/mobile/onboarding/src/main/kotlin/com/flixclusive/feature/mobile/onboarding/component/PermissionsStep.kt
@@ -45,8 +45,10 @@ internal data class GrantedPermissionItem(
 internal fun PermissionsStep(
     notificationsGranted: Boolean,
     unknownSourcesAllowed: Boolean,
+    storageAccessGranted: Boolean,
     grantedPermissions: List<GrantedPermissionItem>,
     requestNotificationsPermission: () -> Unit,
+    requestStorageAccess: () -> Unit,
     openUnknownSourcesSettings: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -70,20 +72,29 @@ internal fun PermissionsStep(
 
         PermissionToggleCard(
             title = stringResource(R.string.onboarding_permission_unknown_sources_title),
-            badgeLabel = stringResource(R.string.permission_unknown_sources_desc),
+            badgeLabel = stringResource(R.string.onboarding_permission_unknown_sources_desc),
             checked = unknownSourcesAllowed,
             enabled = true,
             isRequired = true,
             onToggle = openUnknownSourcesSettings,
         )
 
-        val notificationsChecked = if (Build.VERSION.SDK_INT >= 33) notificationsGranted else true
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            PermissionToggleCard(
+                title = stringResource(R.string.onboarding_permission_storage_access_title),
+                badgeLabel = stringResource(R.string.onboarding_permission_storage_access_desc),
+                checked = storageAccessGranted,
+                enabled = true,
+                isRequired = true,
+                onToggle = requestStorageAccess,
+            )
+        }
 
-        if (Build.VERSION.SDK_INT >= 33) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             PermissionToggleCard(
                 title = stringResource(R.string.onboarding_permission_notifications_title),
-                badgeLabel = stringResource(R.string.permission_notifications_desc),
-                checked = notificationsChecked,
+                badgeLabel = stringResource(R.string.onboarding_permission_notifications_desc),
+                checked = notificationsGranted,
                 enabled = !notificationsGranted,
                 isRequired = false,
                 onToggle = requestNotificationsPermission,

--- a/feature/mobile/onboarding/src/main/res/values/strings.xml
+++ b/feature/mobile/onboarding/src/main/res/values/strings.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="permission_notifications_desc">Used for updates and download status</string>
-    <string name="permission_unknown_sources_desc">Used for auto-updating the app</string>
-
     <string name="onboarding_welcome_title">Welcome!</string>
     <string name="onboarding_welcome_desc">Let\'s get you set up — quick and easy.</string>
+
+    <string name="onboarding_permission_notifications_desc">Used for updates and download status</string>
+    <string name="onboarding_permission_unknown_sources_desc">Used for auto-updating the app</string>
+    <string name="onboarding_permission_storage_access_desc">Used for managing external app data</string>
 
     <string name="onboarding_permissions_title">Permissions</string>
     <string name="onboarding_permissions_desc">Enable what\'s needed.</string>
     <string name="onboarding_permission_unknown_sources_title">Install unknown apps</string>
+    <string name="onboarding_permission_storage_access_title">Storage access</string>
     <string name="onboarding_permission_notifications_title">Notifications</string>
     <string name="onboarding_permissions_required_hint">Enable Install unknown apps to continue.</string>
     <string name="onboarding_permissions_view_granted_button">View other granted permissions</string>


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue. Explain the motivation for the change.

- Moved debug providers on a root level folder instead of `context.getExternalFilesDir(null)` or `/sdcard/Android/data` location

## Checklist:

- [x] I have followed the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for all my commits.
    - Example of a Conventional Commit message: `feat: add new feature to enhance user experience`
