### PR TITLE
fix(provider): resolve unable to load new links for a media

### DIFF
--- a/core/database/schemas/com.flixclusive.core.database.AppDatabase/20.json
+++ b/core/database/schemas/com.flixclusive.core.database.AppDatabase/20.json
@@ -1,0 +1,1293 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 20,
+    "identityHash": "3ca8fd56382a63946ff26d80535f8509",
+    "entities": [
+      {
+        "tableName": "media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `providerId` TEXT NOT NULL, `adult` INTEGER NOT NULL, `type` TEXT NOT NULL, `overview` TEXT, `posterImage` TEXT, `language` TEXT, `rating` REAL, `backdropImage` TEXT, `releaseDate` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "adult",
+            "columnName": "adult",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "posterImage",
+            "columnName": "posterImage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "backdropImage",
+            "columnName": "backdropImage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "releaseDate",
+            "columnName": "releaseDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "media_external_ids",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mediaId` TEXT NOT NULL, `providerId` TEXT NOT NULL, `source` TEXT NOT NULL, `externalId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`mediaId`, `providerId`, `source`), FOREIGN KEY(`mediaId`) REFERENCES `media`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "mediaId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "externalId",
+            "columnName": "externalId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "mediaId",
+            "providerId",
+            "source"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_external_ids_mediaId",
+            "unique": false,
+            "columnNames": [
+              "mediaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_external_ids_mediaId` ON `${TABLE_NAME}` (`mediaId`)"
+          },
+          {
+            "name": "index_media_external_ids_providerId",
+            "unique": false,
+            "columnNames": [
+              "providerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_external_ids_providerId` ON `${TABLE_NAME}` (`providerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "media",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mediaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "media_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS3(`mediaId` TEXT NOT NULL, `title` TEXT NOT NULL, `overview` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "mediaId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS3",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": []
+      },
+      {
+        "tableName": "library_lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `listType` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`ownerId`) REFERENCES `User`(`userId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "listType",
+            "columnName": "listType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_lists_ownerId",
+            "unique": false,
+            "columnNames": [
+              "ownerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_lists_ownerId` ON `${TABLE_NAME}` (`ownerId`)"
+          },
+          {
+            "name": "index_library_lists_ownerId_name",
+            "unique": true,
+            "columnNames": [
+              "ownerId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_library_lists_ownerId_name` ON `${TABLE_NAME}` (`ownerId`, `name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "User",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "ownerId"
+            ],
+            "referencedColumns": [
+              "userId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mediaId` TEXT NOT NULL, `listId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`listId`) REFERENCES `library_lists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`mediaId`) REFERENCES `media`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "mediaId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_list_items_mediaId_listId",
+            "unique": true,
+            "columnNames": [
+              "mediaId",
+              "listId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_library_list_items_mediaId_listId` ON `${TABLE_NAME}` (`mediaId`, `listId`)"
+          },
+          {
+            "name": "index_library_list_items_mediaId",
+            "unique": false,
+            "columnNames": [
+              "mediaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_list_items_mediaId` ON `${TABLE_NAME}` (`mediaId`)"
+          },
+          {
+            "name": "index_library_list_items_listId",
+            "unique": false,
+            "columnNames": [
+              "listId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_list_items_listId` ON `${TABLE_NAME}` (`listId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "library_lists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "listId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "media",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mediaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, FOREIGN KEY(`ownerId`) REFERENCES `User`(`userId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_query_ownerId",
+            "unique": true,
+            "columnNames": [
+              "query",
+              "ownerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_query_ownerId` ON `${TABLE_NAME}` (`query`, `ownerId`)"
+          },
+          {
+            "name": "index_search_history_ownerId",
+            "unique": false,
+            "columnNames": [
+              "ownerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_search_history_ownerId` ON `${TABLE_NAME}` (`ownerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "User",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "ownerId"
+            ],
+            "referencedColumns": [
+              "userId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "User",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `name` TEXT NOT NULL, `image` INTEGER NOT NULL, `pin` TEXT, `pinHint` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `legacyId` INTEGER NOT NULL, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pin",
+            "columnName": "pin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pinHint",
+            "columnName": "pinHint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "legacyId",
+            "columnName": "legacyId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        }
+      },
+      {
+        "tableName": "movies_watch_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mediaId` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `progress` INTEGER NOT NULL, `status` TEXT NOT NULL, `duration` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, FOREIGN KEY(`mediaId`) REFERENCES `media`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`ownerId`) REFERENCES `User`(`userId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "mediaId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_movies_watch_history_mediaId_ownerId",
+            "unique": true,
+            "columnNames": [
+              "mediaId",
+              "ownerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_movies_watch_history_mediaId_ownerId` ON `${TABLE_NAME}` (`mediaId`, `ownerId`)"
+          },
+          {
+            "name": "index_movies_watch_history_mediaId",
+            "unique": false,
+            "columnNames": [
+              "mediaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_watch_history_mediaId` ON `${TABLE_NAME}` (`mediaId`)"
+          },
+          {
+            "name": "index_movies_watch_history_ownerId",
+            "unique": false,
+            "columnNames": [
+              "ownerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_watch_history_ownerId` ON `${TABLE_NAME}` (`ownerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "media",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mediaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "User",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "ownerId"
+            ],
+            "referencedColumns": [
+              "userId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series_watch_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mediaId` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `progress` INTEGER NOT NULL, `status` TEXT NOT NULL, `duration` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `seasonNumber` INTEGER NOT NULL, `episodeNumber` INTEGER NOT NULL, FOREIGN KEY(`mediaId`) REFERENCES `media`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`ownerId`) REFERENCES `User`(`userId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "mediaId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeNumber",
+            "columnName": "episodeNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_series_watch_history_mediaId_ownerId_seasonNumber_episodeNumber",
+            "unique": true,
+            "columnNames": [
+              "mediaId",
+              "ownerId",
+              "seasonNumber",
+              "episodeNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_series_watch_history_mediaId_ownerId_seasonNumber_episodeNumber` ON `${TABLE_NAME}` (`mediaId`, `ownerId`, `seasonNumber`, `episodeNumber`)"
+          },
+          {
+            "name": "index_series_watch_history_mediaId",
+            "unique": false,
+            "columnNames": [
+              "mediaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_watch_history_mediaId` ON `${TABLE_NAME}` (`mediaId`)"
+          },
+          {
+            "name": "index_series_watch_history_ownerId",
+            "unique": false,
+            "columnNames": [
+              "ownerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_watch_history_ownerId` ON `${TABLE_NAME}` (`ownerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "media",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mediaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "User",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "ownerId"
+            ],
+            "referencedColumns": [
+              "userId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "repositories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `userId` TEXT NOT NULL, `owner` TEXT NOT NULL, `name` TEXT NOT NULL, `rawLinkFormat` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`url`, `userId`), FOREIGN KEY(`userId`) REFERENCES `User`(`userId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "owner",
+            "columnName": "owner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawLinkFormat",
+            "columnName": "rawLinkFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url",
+            "userId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_repositories_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_repositories_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "User",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "userId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "installed_providers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `repositoryUrl` TEXT NOT NULL, `filePath` TEXT NOT NULL, `isCatalogEnabled` INTEGER NOT NULL, `isCrossMatchEnabled` INTEGER NOT NULL, `isMediaLinkEnabled` INTEGER NOT NULL, `isMetadataEnabled` INTEGER NOT NULL, `isSearchEnabled` INTEGER NOT NULL, `isTrackerEnabled` INTEGER NOT NULL, `isDebug` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`, `ownerId`), FOREIGN KEY(`repositoryUrl`, `ownerId`) REFERENCES `repositories`(`url`, `userId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repositoryUrl",
+            "columnName": "repositoryUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCatalogEnabled",
+            "columnName": "isCatalogEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCrossMatchEnabled",
+            "columnName": "isCrossMatchEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMediaLinkEnabled",
+            "columnName": "isMediaLinkEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMetadataEnabled",
+            "columnName": "isMetadataEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSearchEnabled",
+            "columnName": "isSearchEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isTrackerEnabled",
+            "columnName": "isTrackerEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDebug",
+            "columnName": "isDebug",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "ownerId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_installed_providers_repositoryUrl",
+            "unique": false,
+            "columnNames": [
+              "repositoryUrl"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_installed_providers_repositoryUrl` ON `${TABLE_NAME}` (`repositoryUrl`)"
+          },
+          {
+            "name": "index_installed_providers_ownerId",
+            "unique": false,
+            "columnNames": [
+              "ownerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_installed_providers_ownerId` ON `${TABLE_NAME}` (`ownerId`)"
+          },
+          {
+            "name": "index_installed_providers_repositoryUrl_ownerId",
+            "unique": false,
+            "columnNames": [
+              "repositoryUrl",
+              "ownerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_installed_providers_repositoryUrl_ownerId` ON `${TABLE_NAME}` (`repositoryUrl`, `ownerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "repositories",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "repositoryUrl",
+              "ownerId"
+            ],
+            "referencedColumns": [
+              "url",
+              "userId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cached_streams",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `label` TEXT NOT NULL, `description` TEXT, `customHeaders` TEXT, `isDead` INTEGER NOT NULL, `providerId` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `mediaId` TEXT NOT NULL, `episodeNumber` INTEGER, `seasonNumber` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `expiresOn` INTEGER, `isThirdPartyGateway` INTEGER NOT NULL, `thirdPartyGatewayName` TEXT, `thirdPartyGatewayLogo` TEXT, PRIMARY KEY(`url`), FOREIGN KEY(`mediaId`) REFERENCES `media`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customHeaders",
+            "columnName": "customHeaders",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDead",
+            "columnName": "isDead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "mediaId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeNumber",
+            "columnName": "episodeNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresOn",
+            "columnName": "expiresOn",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isThirdPartyGateway",
+            "columnName": "isThirdPartyGateway",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thirdPartyGatewayName",
+            "columnName": "thirdPartyGatewayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thirdPartyGatewayLogo",
+            "columnName": "thirdPartyGatewayLogo",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_streams_ownerId",
+            "unique": false,
+            "columnNames": [
+              "ownerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_streams_ownerId` ON `${TABLE_NAME}` (`ownerId`)"
+          },
+          {
+            "name": "index_cached_streams_mediaId",
+            "unique": false,
+            "columnNames": [
+              "mediaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_streams_mediaId` ON `${TABLE_NAME}` (`mediaId`)"
+          },
+          {
+            "name": "index_cached_streams_providerId",
+            "unique": false,
+            "columnNames": [
+              "providerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_streams_providerId` ON `${TABLE_NAME}` (`providerId`)"
+          },
+          {
+            "name": "index_cached_streams_mediaId_seasonNumber_episodeNumber",
+            "unique": false,
+            "columnNames": [
+              "mediaId",
+              "seasonNumber",
+              "episodeNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_streams_mediaId_seasonNumber_episodeNumber` ON `${TABLE_NAME}` (`mediaId`, `seasonNumber`, `episodeNumber`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "media",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mediaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cached_subtitles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `language` TEXT NOT NULL, `description` TEXT, `customHeaders` TEXT, `isDead` INTEGER NOT NULL, `providerId` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `mediaId` TEXT NOT NULL, `episodeNumber` INTEGER, `seasonNumber` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `subtitleSource` TEXT NOT NULL, PRIMARY KEY(`url`), FOREIGN KEY(`mediaId`) REFERENCES `media`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customHeaders",
+            "columnName": "customHeaders",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDead",
+            "columnName": "isDead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerId",
+            "columnName": "providerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "mediaId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeNumber",
+            "columnName": "episodeNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitleSource",
+            "columnName": "subtitleSource",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_subtitles_ownerId",
+            "unique": false,
+            "columnNames": [
+              "ownerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_subtitles_ownerId` ON `${TABLE_NAME}` (`ownerId`)"
+          },
+          {
+            "name": "index_cached_subtitles_mediaId",
+            "unique": false,
+            "columnNames": [
+              "mediaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_subtitles_mediaId` ON `${TABLE_NAME}` (`mediaId`)"
+          },
+          {
+            "name": "index_cached_subtitles_providerId",
+            "unique": false,
+            "columnNames": [
+              "providerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_subtitles_providerId` ON `${TABLE_NAME}` (`providerId`)"
+          },
+          {
+            "name": "index_cached_subtitles_mediaId_seasonNumber_episodeNumber",
+            "unique": false,
+            "columnNames": [
+              "mediaId",
+              "seasonNumber",
+              "episodeNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_subtitles_mediaId_seasonNumber_episodeNumber` ON `${TABLE_NAME}` (`mediaId`, `seasonNumber`, `episodeNumber`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "media",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mediaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [
+      {
+        "viewName": "library_list_item_with_metadata",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT library_list_items.id AS item_id, library_list_items.mediaId AS item_mediaId, library_list_items.listId AS item_listId, library_list_items.createdAt AS item_createdAt, library_list_items.updatedAt AS item_updatedAt, media.id AS media_id, media.title AS media_title, media.providerId AS media_providerId, media.type AS media_type, media.overview AS media_overview, media.posterImage AS media_posterImage, media.adult AS media_adult, media.language AS media_language, media.rating AS media_rating, media.backdropImage AS media_backdropImage, media.releaseDate AS media_releaseDate, media.createdAt AS media_createdAt, media.updatedAt AS media_updatedAt FROM library_list_items INNER JOIN media ON library_list_items.mediaId = media.id"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3ca8fd56382a63946ff26d80535f8509')"
+    ]
+  }
+}

--- a/core/database/src/main/kotlin/com/flixclusive/core/database/AppDatabase.kt
+++ b/core/database/src/main/kotlin/com/flixclusive/core/database/AppDatabase.kt
@@ -39,6 +39,7 @@ import com.flixclusive.core.database.migration.Schema15to16
 import com.flixclusive.core.database.migration.Schema16to17
 import com.flixclusive.core.database.migration.Schema17to18
 import com.flixclusive.core.database.migration.Schema18to19
+import com.flixclusive.core.database.migration.Schema19to20
 import com.flixclusive.core.database.migration.Schema1to2
 import com.flixclusive.core.database.migration.Schema2to3
 import com.flixclusive.core.database.migration.Schema3to4
@@ -69,7 +70,7 @@ internal const val APP_DATABASE = "app_database"
         CachedSubtitle::class,
     ],
     views = [LibraryListItemWithMetadata::class],
-    version = 19,
+    version = 20,
     exportSchema = true,
 )
 @TypeConverters(
@@ -130,6 +131,7 @@ abstract class AppDatabase : RoomDatabase() {
                         Schema16to17,
                         Schema17to18,
                         Schema18to19,
+                        Schema19to20,
                     ).build()
                     .also { INSTANCE = it }
             }

--- a/core/database/src/main/kotlin/com/flixclusive/core/database/dao/provider/CachedMediaLinkDao.kt
+++ b/core/database/src/main/kotlin/com/flixclusive/core/database/dao/provider/CachedMediaLinkDao.kt
@@ -1,39 +1,54 @@
 package com.flixclusive.core.database.dao.provider
 
 import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
+import androidx.room.Upsert
 import com.flixclusive.core.database.entity.media.DBMedia
+import com.flixclusive.core.database.entity.media.DBMedia.Companion.toDBMedia
 import com.flixclusive.core.database.entity.media.DBMediaExternalId
+import com.flixclusive.core.database.entity.media.DBMediaExternalId.Companion.toDBMediaExternalIds
+import com.flixclusive.core.database.entity.media.DBMediaFts
+import com.flixclusive.core.database.entity.media.DBMediaFts.Companion.toDBMediaFts
 import com.flixclusive.core.database.entity.provider.CachedStream
 import com.flixclusive.core.database.entity.provider.CachedSubtitle
+import com.flixclusive.core.database.entity.provider.EpisodeLinks
+import com.flixclusive.core.database.entity.provider.MediaLinksWithData
+import com.flixclusive.core.database.entity.provider.SeasonLinks
+import com.flixclusive.model.media.MediaMetadata
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import java.util.Date
 
 @Dao
 interface CachedMediaLinkDao {
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    @Upsert
     suspend fun insertStream(stream: CachedStream)
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    @Upsert
     suspend fun insertSubtitle(subtitle: CachedSubtitle)
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
-    suspend fun insertMedia(media: DBMedia): Long
+    @Upsert
+    suspend fun insertMedia(media: DBMedia)
+
+    @Upsert
+    suspend fun insertMediaFts(mediaFts: DBMediaFts)
+
+    @Upsert
+    suspend fun insertMediaIds(externalIds: List<DBMediaExternalId>)
 
     @Transaction
-    suspend fun upsertLinks(
-        media: DBMedia,
-        streams: List<CachedStream>,
-        subtitles: List<CachedSubtitle>,
-    ) {
-        insertMedia(media)
-        streams.forEach { insertStream(it) }
-        subtitles.forEach { insertSubtitle(it) }
+    suspend fun upsertMedia(media: MediaMetadata) {
+        val existingMedia = getMediaByIds(
+            mediaId = media.id,
+            providerId = media.providerId
+        ) ?: media.toDBMedia()
+
+        insertMedia(existingMedia.copy(updatedAt = Date()))
+        insertMediaFts(media.toDBMediaFts())
+        insertMediaIds(media.toDBMediaExternalIds())
     }
 
     @Query("UPDATE cached_streams SET isDead = :isDead, updatedAt = :now WHERE url = :url AND ownerId = :ownerId")
@@ -221,6 +236,9 @@ interface CachedMediaLinkDao {
     @Query("SELECT * FROM media WHERE id = :mediaId")
     suspend fun getMediaById(mediaId: String): DBMedia?
 
+    @Query("SELECT * FROM media WHERE id = :mediaId AND providerId = :providerId")
+    suspend fun getMediaByIds(mediaId: String, providerId: String): DBMedia?
+
     @Query(
         """
         SELECT * FROM cached_streams
@@ -258,6 +276,9 @@ interface CachedMediaLinkDao {
     @Query("SELECT * FROM media_external_ids WHERE mediaId = :mediaId")
     suspend fun getExternalIdsByMediaId(mediaId: String): List<DBMediaExternalId>
 
+    @Query("SELECT * FROM media_external_ids WHERE mediaId = :mediaId AND providerId = :providerId")
+    suspend fun getExternalIdsByIds(mediaId: String, providerId: String): List<DBMediaExternalId>
+
     @Transaction
     suspend fun getLinks(
         ownerId: String,
@@ -281,15 +302,15 @@ interface CachedMediaLinkDao {
         episodeNumber: Int?,
         seasonNumber: Int?,
     ): MediaLinksWithData? {
-        val media = getMediaById(mediaId) ?: return null
-        val externalIds = getExternalIdsByMediaId(mediaId)
+        val media = getMediaByIds(mediaId, providerId) ?: return null
+        val externalIds = getExternalIdsByIds(mediaId, providerId)
         val streams = getStreams(mediaId, ownerId, providerId, episodeNumber, seasonNumber)
         val subtitles = getSubtitles(mediaId, ownerId, providerId, episodeNumber, seasonNumber)
 
         if (streams.isEmpty() && subtitles.isEmpty()) return null
 
         return MediaLinksWithData(
-            media = media.copy(providerId = providerId),
+            media = media,
             streams = streams,
             subtitles = subtitles,
             externalIds = externalIds,
@@ -484,30 +505,4 @@ interface CachedMediaLinkDao {
             )
         }
     }
-}
-
-data class SeasonLinks(
-    val number: Int,
-    val count: Int
-)
-
-data class EpisodeLinks(
-    val number: Int,
-    val count: Int,
-    val lastUpdated: Long?
-)
-
-data class MediaLinksWithData(
-    val media: DBMedia,
-    val streams: List<CachedStream> = emptyList(),
-    val subtitles: List<CachedSubtitle> = emptyList(),
-    val externalIds: List<DBMediaExternalId> = emptyList(),
-) {
-    val providerId: String get() = media.providerId
-    val ownerId: String? get() = streams.firstOrNull()?.ownerId ?: subtitles.firstOrNull()?.ownerId
-    val episodeNumber: Int? get() = streams.firstOrNull()?.episodeNumber ?: subtitles.firstOrNull()?.episodeNumber
-    val seasonNumber: Int? get() = streams.firstOrNull()?.seasonNumber ?: subtitles.firstOrNull()?.seasonNumber
-
-    val size: Int get() = streams.size + subtitles.size
-    val hasValidLinks: Boolean get() = streams.any { it.isValid }
 }

--- a/core/database/src/main/kotlin/com/flixclusive/core/database/entity/provider/CachedStream.kt
+++ b/core/database/src/main/kotlin/com/flixclusive/core/database/entity/provider/CachedStream.kt
@@ -14,7 +14,6 @@ import java.util.Date
             entity = DBMedia::class,
             parentColumns = ["id"],
             childColumns = ["mediaId"],
-            onDelete = ForeignKey.CASCADE,
         ),
     ],
     indices = [

--- a/core/database/src/main/kotlin/com/flixclusive/core/database/entity/provider/CachedSubtitle.kt
+++ b/core/database/src/main/kotlin/com/flixclusive/core/database/entity/provider/CachedSubtitle.kt
@@ -15,7 +15,6 @@ import java.util.Date
             entity = DBMedia::class,
             parentColumns = ["id"],
             childColumns = ["mediaId"],
-            onDelete = ForeignKey.CASCADE,
         ),
     ],
     indices = [

--- a/core/database/src/main/kotlin/com/flixclusive/core/database/entity/provider/EpisodeLinks.kt
+++ b/core/database/src/main/kotlin/com/flixclusive/core/database/entity/provider/EpisodeLinks.kt
@@ -1,0 +1,7 @@
+package com.flixclusive.core.database.entity.provider
+
+data class EpisodeLinks(
+    val number: Int,
+    val count: Int,
+    val lastUpdated: Long?
+)

--- a/core/database/src/main/kotlin/com/flixclusive/core/database/entity/provider/MediaLinksWithData.kt
+++ b/core/database/src/main/kotlin/com/flixclusive/core/database/entity/provider/MediaLinksWithData.kt
@@ -1,0 +1,19 @@
+package com.flixclusive.core.database.entity.provider
+
+import com.flixclusive.core.database.entity.media.DBMedia
+import com.flixclusive.core.database.entity.media.DBMediaExternalId
+
+data class MediaLinksWithData(
+    val media: DBMedia,
+    val streams: List<CachedStream> = emptyList(),
+    val subtitles: List<CachedSubtitle> = emptyList(),
+    val externalIds: List<DBMediaExternalId> = emptyList(),
+) {
+    val providerId: String get() = media.providerId
+    val ownerId: String? get() = streams.firstOrNull()?.ownerId ?: subtitles.firstOrNull()?.ownerId
+    val episodeNumber: Int? get() = streams.firstOrNull()?.episodeNumber ?: subtitles.firstOrNull()?.episodeNumber
+    val seasonNumber: Int? get() = streams.firstOrNull()?.seasonNumber ?: subtitles.firstOrNull()?.seasonNumber
+
+    val size: Int get() = streams.size + subtitles.size
+    val hasValidLinks: Boolean get() = streams.any { it.isValid }
+}

--- a/core/database/src/main/kotlin/com/flixclusive/core/database/entity/provider/SeasonLinks.kt
+++ b/core/database/src/main/kotlin/com/flixclusive/core/database/entity/provider/SeasonLinks.kt
@@ -1,0 +1,6 @@
+package com.flixclusive.core.database.entity.provider
+
+data class SeasonLinks(
+    val number: Int,
+    val count: Int
+)

--- a/core/database/src/main/kotlin/com/flixclusive/core/database/migration/Schema19to20.kt
+++ b/core/database/src/main/kotlin/com/flixclusive/core/database/migration/Schema19to20.kt
@@ -1,0 +1,87 @@
+package com.flixclusive.core.database.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+internal object Schema19to20 : Migration(19, 20) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        // 1. Recreate cached_streams without CASCADE
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `cached_streams_new` (
+                `url` TEXT NOT NULL,
+                `label` TEXT NOT NULL,
+                `description` TEXT,
+                `customHeaders` TEXT,
+                `isDead` INTEGER NOT NULL,
+                `providerId` TEXT NOT NULL,
+                `ownerId` TEXT NOT NULL,
+                `mediaId` TEXT NOT NULL,
+                `episodeNumber` INTEGER,
+                `seasonNumber` INTEGER,
+                `createdAt` INTEGER NOT NULL,
+                `updatedAt` INTEGER NOT NULL,
+                `expiresOn` INTEGER,
+                `isThirdPartyGateway` INTEGER NOT NULL,
+                `thirdPartyGatewayName` TEXT,
+                `thirdPartyGatewayLogo` TEXT,
+                PRIMARY KEY(`url`),
+                FOREIGN KEY(`mediaId`) REFERENCES `media`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION
+            )
+            """.trimIndent()
+        )
+        db.execSQL("INSERT INTO `cached_streams_new` SELECT * FROM `cached_streams`")
+        db.execSQL("DROP TABLE `cached_streams`")
+        db.execSQL("ALTER TABLE `cached_streams_new` RENAME TO `cached_streams`")
+
+        // Re-create indices for cached_streams
+        db.execSQL("CREATE INDEX IF NOT EXISTS `index_cached_streams_ownerId` ON `cached_streams` (`ownerId`)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS `index_cached_streams_mediaId` ON `cached_streams` (`mediaId`)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS `index_cached_streams_providerId` ON `cached_streams` (`providerId`)")
+        db.execSQL(
+            """
+            CREATE INDEX IF NOT EXISTS `index_cached_streams_mediaId_seasonNumber_episodeNumber` ON `cached_streams` (`mediaId`, `seasonNumber`, `episodeNumber`)
+            """.trimIndent()
+        )
+
+        // 2. Recreate cached_subtitles without CASCADE
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `cached_subtitles_new` (
+                `url` TEXT NOT NULL,
+                `language` TEXT NOT NULL,
+                `description` TEXT,
+                `customHeaders` TEXT,
+                `isDead` INTEGER NOT NULL,
+                `providerId` TEXT NOT NULL,
+                `ownerId` TEXT NOT NULL,
+                `mediaId` TEXT NOT NULL,
+                `episodeNumber` INTEGER,
+                `seasonNumber` INTEGER,
+                `createdAt` INTEGER NOT NULL,
+                `updatedAt` INTEGER NOT NULL,
+                `subtitleSource` TEXT NOT NULL,
+                PRIMARY KEY(`url`),
+                FOREIGN KEY(`mediaId`) REFERENCES `media`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION
+            )
+            """.trimIndent()
+        )
+        db.execSQL("INSERT INTO `cached_subtitles_new` SELECT * FROM `cached_subtitles`")
+        db.execSQL("DROP TABLE `cached_subtitles`")
+        db.execSQL("ALTER TABLE `cached_subtitles_new` RENAME TO `cached_subtitles`")
+
+        // Re-create indices for cached_subtitles
+        db.execSQL("CREATE INDEX IF NOT EXISTS `index_cached_subtitles_ownerId` ON `cached_subtitles` (`ownerId`)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS `index_cached_subtitles_mediaId` ON `cached_subtitles` (`mediaId`)")
+        db.execSQL(
+            """
+            CREATE INDEX IF NOT EXISTS `index_cached_subtitles_providerId` ON `cached_subtitles` (`providerId`)
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            CREATE INDEX IF NOT EXISTS `index_cached_subtitles_mediaId_seasonNumber_episodeNumber` ON `cached_subtitles` (`mediaId`, `seasonNumber`, `episodeNumber`)
+            """.trimIndent()
+        )
+    }
+}

--- a/data/provider/src/main/kotlin/com/flixclusive/data/provider/repository/MediaLinksRepository.kt
+++ b/data/provider/src/main/kotlin/com/flixclusive/data/provider/repository/MediaLinksRepository.kt
@@ -1,19 +1,16 @@
 package com.flixclusive.data.provider.repository
 
-import com.flixclusive.core.database.dao.provider.EpisodeLinks
-import com.flixclusive.core.database.dao.provider.MediaLinksWithData
-import com.flixclusive.core.database.dao.provider.SeasonLinks
-import com.flixclusive.core.database.entity.media.DBMedia
 import com.flixclusive.core.database.entity.provider.CachedMediaLink
+import com.flixclusive.core.database.entity.provider.EpisodeLinks
+import com.flixclusive.core.database.entity.provider.MediaLinksWithData
+import com.flixclusive.core.database.entity.provider.SeasonLinks
+import com.flixclusive.model.media.MediaMetadata
 import kotlinx.coroutines.flow.Flow
 
 interface MediaLinksRepository {
-    suspend fun upsertLinks(
-        media: DBMedia,
-        links: List<CachedMediaLink>
-    )
-
     suspend fun upsertLink(link: CachedMediaLink)
+
+    suspend fun upsertMedia(media: MediaMetadata)
 
     suspend fun getLinks(
         ownerId: String,

--- a/data/provider/src/main/kotlin/com/flixclusive/data/provider/repository/impl/MediaLinksRepositoryImpl.kt
+++ b/data/provider/src/main/kotlin/com/flixclusive/data/provider/repository/impl/MediaLinksRepositoryImpl.kt
@@ -2,14 +2,14 @@ package com.flixclusive.data.provider.repository.impl
 
 import com.flixclusive.core.common.dispatchers.AppDispatchers
 import com.flixclusive.core.database.dao.provider.CachedMediaLinkDao
-import com.flixclusive.core.database.dao.provider.EpisodeLinks
-import com.flixclusive.core.database.dao.provider.MediaLinksWithData
-import com.flixclusive.core.database.dao.provider.SeasonLinks
-import com.flixclusive.core.database.entity.media.DBMedia
 import com.flixclusive.core.database.entity.provider.CachedMediaLink
 import com.flixclusive.core.database.entity.provider.CachedStream
 import com.flixclusive.core.database.entity.provider.CachedSubtitle
+import com.flixclusive.core.database.entity.provider.EpisodeLinks
+import com.flixclusive.core.database.entity.provider.MediaLinksWithData
+import com.flixclusive.core.database.entity.provider.SeasonLinks
 import com.flixclusive.data.provider.repository.MediaLinksRepository
+import com.flixclusive.model.media.MediaMetadata
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -18,13 +18,9 @@ internal class MediaLinksRepositoryImpl @Inject constructor(
     private val cachedMediaLinkDao: CachedMediaLinkDao,
     private val appDispatchers: AppDispatchers
 ) : MediaLinksRepository {
-    override suspend fun upsertLinks(media: DBMedia, links: List<CachedMediaLink>) {
+    override suspend fun upsertMedia(media: MediaMetadata) {
         withContext(appDispatchers.io) {
-            cachedMediaLinkDao.upsertLinks(
-                media = media,
-                streams = links.filterIsInstance<CachedStream>(),
-                subtitles = links.filterIsInstance<CachedSubtitle>()
-            )
+            cachedMediaLinkDao.upsertMedia(media)
         }
     }
 
@@ -132,12 +128,17 @@ internal class MediaLinksRepositoryImpl @Inject constructor(
     ) {
         withContext(appDispatchers.io) {
             when {
-                episodeNumber != null && seasonNumber != null ->
+                episodeNumber != null && seasonNumber != null -> {
                     cachedMediaLinkDao.deleteLinksByEpisode(ownerId, mediaId, seasonNumber, episodeNumber)
-                seasonNumber != null ->
+                }
+
+                seasonNumber != null -> {
                     cachedMediaLinkDao.deleteLinksBySeason(ownerId, mediaId, seasonNumber)
-                else ->
+                }
+
+                else -> {
                     cachedMediaLinkDao.deleteLinksByMedia(ownerId, mediaId)
+                }
             }
         }
     }

--- a/domain/provider/src/main/kotlin/com/flixclusive/domain/provider/usecase/get/impl/GetMediaLinksUseCaseImpl.kt
+++ b/domain/provider/src/main/kotlin/com/flixclusive/domain/provider/usecase/get/impl/GetMediaLinksUseCaseImpl.kt
@@ -71,6 +71,8 @@ internal class GetMediaLinksUseCaseImpl @Inject constructor(
             return@channelFlow
         }
 
+        mediaLinksRepository.upsertMedia(media)
+
         val provider = providerRepository.getProvider(media.providerId, userId)
         if (provider == null) {
             warnLog("Failed to fetch media links: no provider plugin found for id: ${media.providerId}")

--- a/domain/provider/src/main/kotlin/com/flixclusive/domain/provider/usecase/manage/impl/InstallProviderUseCaseImpl.kt
+++ b/domain/provider/src/main/kotlin/com/flixclusive/domain/provider/usecase/manage/impl/InstallProviderUseCaseImpl.kt
@@ -77,7 +77,7 @@ internal class InstallProviderUseCaseImpl @Inject constructor(
                 )
             } catch (e: Throwable) {
                 errorLog("Failed to download provider: ${metadata.name}")
-                errorLog(e)
+                errorLog(e.cause)
 
                 send(
                     DownloadProviderResult.Failure(

--- a/feature/mobile/player/src/main/java/com/flixclusive/feature/mobile/player/PlayerScreenViewModel.kt
+++ b/feature/mobile/player/src/main/java/com/flixclusive/feature/mobile/player/PlayerScreenViewModel.kt
@@ -15,10 +15,10 @@ import com.flixclusive.core.common.dispatchers.AppDispatchers
 import com.flixclusive.core.common.domain.Async
 import com.flixclusive.core.common.locale.UiText
 import com.flixclusive.core.common.provider.LoadLinksState
-import com.flixclusive.core.database.dao.provider.MediaLinksWithData
 import com.flixclusive.core.database.entity.media.DBMedia.Companion.toDBMedia
 import com.flixclusive.core.database.entity.media.DBMediaExternalId.Companion.toDBMediaExternalIds
 import com.flixclusive.core.database.entity.provider.CachedStream
+import com.flixclusive.core.database.entity.provider.MediaLinksWithData
 import com.flixclusive.core.database.entity.watched.EpisodeProgress
 import com.flixclusive.core.database.entity.watched.MovieProgress
 import com.flixclusive.core.database.entity.watched.WatchProgress

--- a/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/links/show/MediaLinksShowDetailTweakScreen.kt
+++ b/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/links/show/MediaLinksShowDetailTweakScreen.kt
@@ -40,8 +40,8 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.flixclusive.core.common.domain.Async
 import com.flixclusive.core.common.domain.Async.Companion.AsyncAnimatedContent
-import com.flixclusive.core.database.dao.provider.EpisodeLinks
-import com.flixclusive.core.database.dao.provider.SeasonLinks
+import com.flixclusive.core.database.entity.provider.EpisodeLinks
+import com.flixclusive.core.database.entity.provider.SeasonLinks
 import com.flixclusive.core.navigation.navigator.NavigateBack
 import com.flixclusive.core.navigation.navigator.NavigateToManageMediaLinksScreen
 import com.flixclusive.core.presentation.mobile.components.EmptyDataMessage


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue. Explain the motivation for the change.

- Fixes issue where any media will dispay "Juiceless ..." due to incorrect SQL constraint for persisted media on DB when upserting new links. The media weren't present before upserting.

## Checklist:

- [x] I have followed the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for all my commits.
    - Example of a Conventional Commit message: `feat: add new feature to enhance user experience`
