### PR TITLE
feat(settings): add logcat viewer

### DIFF
--- a/app-mobile/src/main/kotlin/com/flixclusive/navigation/MobileAppNavigator.kt
+++ b/app-mobile/src/main/kotlin/com/flixclusive/navigation/MobileAppNavigator.kt
@@ -46,6 +46,7 @@ import com.flixclusive.feature.mobile.settings.screen.links.show.NavigatorMediaL
 import com.flixclusive.feature.mobile.settings.screen.player.NavigatorPlayerTweakScreen
 import com.flixclusive.feature.mobile.settings.screen.providers.NavigatorProvidersTweakScreen
 import com.flixclusive.feature.mobile.settings.screen.root.NavigatorSettingsScreen
+import com.flixclusive.feature.mobile.settings.screen.system.NavigatorSystemTweakScreen
 import com.flixclusive.feature.mobile.user.add.NavigatorAddUserScreenNavigateTo
 import com.flixclusive.feature.mobile.user.edit.NavigatorUserEditScreen
 import com.flixclusive.feature.mobile.user.profiles.NavigatorUserProfilesScreen
@@ -89,6 +90,7 @@ import com.ramcosta.composedestinations.generated.repositorymanage.destinations.
 import com.ramcosta.composedestinations.generated.settings.destinations.AppearanceTweakScreenDestination
 import com.ramcosta.composedestinations.generated.settings.destinations.DataTweakScreenDestination
 import com.ramcosta.composedestinations.generated.settings.destinations.DownloadsTweakScreenDestination
+import com.ramcosta.composedestinations.generated.settings.destinations.LogcatTweakScreenDestination
 import com.ramcosta.composedestinations.generated.settings.destinations.ManageMediaLinksTweakScreenDestination
 import com.ramcosta.composedestinations.generated.settings.destinations.MediaLinkCardsTweakScreenDestination
 import com.ramcosta.composedestinations.generated.settings.destinations.MediaLinksShowDetailTweakScreenDestination
@@ -143,6 +145,7 @@ internal class MobileAppNavigator(
     NavigatorOnboardingScreen,
     NavigatorPlayerSplashScreen,
     NavigatorPlayerTweakScreen,
+    NavigatorSystemTweakScreen,
     NavigatorProviderDetailsBottomSheet,
     NavigatorProviderManagerScreen,
     NavigatorProvidersTweakScreen,
@@ -454,6 +457,12 @@ internal class MobileAppNavigator(
     override fun navigateToMediaLinkCardsTweakScreen() {
         runOnResumed {
             navigator.navigate(MediaLinkCardsTweakScreenDestination)
+        }
+    }
+
+    override fun navigateToLogcatTweakScreen() {
+        runOnResumed {
+            navigator.navigate(LogcatTweakScreenDestination)
         }
     }
 

--- a/app-mobile/src/main/kotlin/com/flixclusive/navigation/navgraph/SettingsNavGraph.kt
+++ b/app-mobile/src/main/kotlin/com/flixclusive/navigation/navgraph/SettingsNavGraph.kt
@@ -9,6 +9,7 @@ import com.ramcosta.composedestinations.generated.repositorymanage.destinations.
 import com.ramcosta.composedestinations.generated.settings.destinations.AppearanceTweakScreenDestination
 import com.ramcosta.composedestinations.generated.settings.destinations.DataTweakScreenDestination
 import com.ramcosta.composedestinations.generated.settings.destinations.DownloadsTweakScreenDestination
+import com.ramcosta.composedestinations.generated.settings.destinations.LogcatTweakScreenDestination
 import com.ramcosta.composedestinations.generated.settings.destinations.ManageMediaLinksTweakScreenDestination
 import com.ramcosta.composedestinations.generated.settings.destinations.MediaLinkCardsTweakScreenDestination
 import com.ramcosta.composedestinations.generated.settings.destinations.MediaLinksShowDetailTweakScreenDestination
@@ -34,5 +35,6 @@ internal annotation class SettingsNavGraph {
     @ExternalDestination<ManageMediaLinksTweakScreenDestination>
     @ExternalDestination<MediaLinksShowDetailTweakScreenDestination>
     @ExternalDestination<DownloadsTweakScreenDestination>
+    @ExternalDestination<LogcatTweakScreenDestination>
     companion object Includes
 }

--- a/core/drawables/src/main/res/drawable/more_vert.xml
+++ b/core/drawables/src/main/res/drawable/more_vert.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:tint="#000000"
+        android:viewportWidth="24"
+        android:viewportHeight="24">
+    <path
+            android:fillColor="@android:color/white"
+            android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z" />
+</vector>

--- a/core/drawables/src/main/res/drawable/share.xml
+++ b/core/drawables/src/main/res/drawable/share.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:tint="#000000"
+        android:viewportWidth="24"
+        android:viewportHeight="24">
+    <path
+            android:fillColor="@android:color/white"
+            android:pathData="M18,16.08c-0.76,0 -1.44,0.3 -1.96,0.77L8.91,12.7c0.05,-0.23 0.09,-0.46 0.09,-0.7s-0.04,-0.47 -0.09,-0.7l7.05,-4.11c0.54,0.5 1.25,0.81 2.04,0.81 1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3c0,0.24 0.04,0.47 0.09,0.7L8.04,9.81C7.5,9.31 6.79,9 6,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3c0.79,0 1.5,-0.31 2.04,-0.81l7.12,4.16c-0.05,0.21 -0.08,0.43 -0.08,0.65 0,1.61 1.31,2.92 2.92,2.92s2.92,-1.31 2.92,-2.92 -1.31,-2.92 -2.92,-2.92z" />
+</vector>

--- a/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/SystemTweakScreen.kt
+++ b/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/SystemTweakScreen.kt
@@ -13,6 +13,7 @@ import com.flixclusive.core.datastore.model.system.SystemPreferences
 import com.flixclusive.core.datastore.model.user.network.DoHPreference
 import com.flixclusive.core.navigation.navigator.NavigateBack
 import com.flixclusive.core.presentation.common.extensions.showToast
+import com.flixclusive.feature.mobile.settings.R
 import com.flixclusive.feature.mobile.settings.TweakGroup
 import com.flixclusive.feature.mobile.settings.TweakScaffold
 import com.flixclusive.feature.mobile.settings.TweakUI
@@ -21,12 +22,17 @@ import com.ramcosta.composedestinations.annotation.ExternalModuleGraph
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableMap
+import com.flixclusive.core.drawables.R as UiCommonR
 import com.flixclusive.core.strings.R as LocaleR
+
+interface NavigatorSystemTweakScreen : NavigateBack {
+    fun navigateToLogcatTweakScreen()
+}
 
 @Destination<ExternalModuleGraph>
 @Composable
 internal fun SystemTweakScreen(
-    navigator: NavigateBack,
+    navigator: NavigatorSystemTweakScreen,
     viewModel: SystemTweakViewModel = hiltViewModel()
 ) {
     val systemPreferences by viewModel.preferences.collectAsStateWithLifecycle()
@@ -43,7 +49,8 @@ internal fun SystemTweakScreen(
                 getNetworkTweaks(
                     systemPreferences = { systemPreferences },
                     onUpdatePreferences = viewModel::updateSystemPrefs,
-                )
+                ),
+                getDebugTweaks(onOpenLogcat = navigator::navigateToLogcatTweakScreen),
             )
         }
     )
@@ -133,6 +140,23 @@ private fun getNetworkTweaks(
                         context.showToast(message)
                     }
                 },
+            ),
+        ),
+    )
+}
+
+@Composable
+private fun getDebugTweaks(onOpenLogcat: () -> Unit): TweakGroup {
+    val resources = LocalResources.current
+
+    return TweakGroup(
+        title = stringResource(R.string.logcat_group_title),
+        tweaks = persistentListOf(
+            TweakUI.ClickableTweak(
+                title = resources.getString(R.string.logcat),
+                description = { resources.getString(R.string.logcat_content_desc) },
+                iconId = UiCommonR.drawable.bug_thin,
+                onClick = onOpenLogcat,
             ),
         ),
     )

--- a/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogEntry.kt
+++ b/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogEntry.kt
@@ -1,0 +1,52 @@
+package com.flixclusive.feature.mobile.settings.screen.system.logcat
+
+import androidx.compose.runtime.Immutable
+
+internal enum class LogLevel(
+    val letter: Char,
+) {
+    VERBOSE('V'),
+    DEBUG('D'),
+    INFO('I'),
+    WARN('W'),
+    ERROR('E'),
+    ASSERT('F'),
+    SILENT('S'),
+    ;
+
+    companion object {
+        fun fromLetter(letter: Char): LogLevel? = entries.firstOrNull { it.letter == letter }
+
+        /**
+         * Resolves a user-typed level token. Accepts the single letter, the full name, or any
+         * unambiguous prefix of it, so `level:e`, `level:err` and `level:ERROR` all mean the same
+         * thing the way they do in Android Studio.
+         */
+        fun fromToken(token: String): LogLevel? {
+            if (token.isEmpty()) return null
+
+            val normalized = token.uppercase()
+            if (normalized.length == 1) {
+                return fromLetter(normalized[0])
+            }
+
+            val matches = entries.filter { it.name.startsWith(normalized) }
+            return matches.singleOrNull()
+        }
+    }
+}
+
+@Immutable
+internal data class LogEntry(
+    val id: Long,
+    val date: String,
+    val time: String,
+    val pid: Int,
+    val tid: Int,
+    val level: LogLevel,
+    val tag: String,
+    val message: String,
+    val isContinuation: Boolean,
+    val text: String,
+    val messageStart: Int,
+)

--- a/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogFilter.kt
+++ b/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogFilter.kt
@@ -1,0 +1,152 @@
+package com.flixclusive.feature.mobile.settings.screen.system.logcat
+
+import androidx.compose.runtime.Immutable
+
+internal enum class FilterKey {
+    TAG,
+    MESSAGE,
+    PACKAGE,
+    LEVEL,
+    PID,
+    TID,
+    ;
+
+    companion object {
+        fun fromToken(token: String): FilterKey? =
+            when (token.lowercase()) {
+                "tag" -> TAG
+                "message", "msg" -> MESSAGE
+                "package", "pkg" -> PACKAGE
+                "level" -> LEVEL
+                "pid" -> PID
+                "tid" -> TID
+                else -> null
+            }
+    }
+}
+
+internal sealed interface ValueMatcher {
+    fun matches(candidate: String): Boolean
+
+    @Immutable
+    data class Substring(
+        val value: String,
+    ) : ValueMatcher {
+        override fun matches(candidate: String) = candidate.contains(value, ignoreCase = true)
+    }
+
+    @Immutable
+    data class Exact(
+        val value: String,
+    ) : ValueMatcher {
+        override fun matches(candidate: String) = candidate.equals(value, ignoreCase = true)
+    }
+
+    @Immutable
+    data class Pattern(
+        val regex: Regex,
+    ) : ValueMatcher {
+        override fun matches(candidate: String) = regex.containsMatchIn(candidate)
+    }
+}
+
+/**
+ * The pid and package name are injected rather than read from [android.os.Process] inside the
+ * matcher so the whole filter layer stays free of Android types and testable on the JVM.
+ */
+internal data class LogFilterContext(
+    val ownPid: Int,
+    val ownPackageName: String,
+)
+
+internal sealed interface LogFilter {
+    data object MatchAll : LogFilter
+
+    @Immutable
+    data class Not(
+        val term: LogFilter,
+    ) : LogFilter
+
+    @Immutable
+    data class And(
+        val terms: List<LogFilter>,
+    ) : LogFilter
+
+    @Immutable
+    data class Field(
+        val key: FilterKey,
+        val matcher: ValueMatcher,
+    ) : LogFilter
+
+    @Immutable
+    data class Bare(
+        val matcher: ValueMatcher,
+    ) : LogFilter
+}
+
+internal fun LogFilter.matches(
+    entry: LogEntry,
+    context: LogFilterContext,
+): Boolean =
+    when (this) {
+        is LogFilter.MatchAll -> true
+        is LogFilter.Not -> !term.matches(entry, context)
+        is LogFilter.And -> terms.all { it.matches(entry, context) }
+        is LogFilter.Bare -> matcher.matches(entry.text)
+        is LogFilter.Field -> matchesField(entry, context)
+    }
+
+private fun LogFilter.Field.matchesField(
+    entry: LogEntry,
+    context: LogFilterContext,
+): Boolean =
+    when (key) {
+        FilterKey.TAG -> matcher.matches(entry.tag)
+        FilterKey.MESSAGE -> matcher.matches(entry.message)
+        FilterKey.PID -> matchesNumber(entry.pid)
+        FilterKey.TID -> matchesNumber(entry.tid)
+        FilterKey.LEVEL -> matchesLevel(entry)
+        FilterKey.PACKAGE -> matchesPackage(entry, context)
+    }
+
+private fun LogFilter.Field.matchesNumber(value: Int): Boolean {
+    val expected = matcher.literalOrNull()?.toIntOrNull() ?: return false
+    return value == expected
+}
+
+/**
+ * `level:W` means WARN *and above*, matching Android Studio. A regex matcher falls back to matching
+ * the level letter so `level~:[WE]` still does something sensible.
+ */
+private fun LogFilter.Field.matchesLevel(entry: LogEntry): Boolean {
+    val literal = matcher.literalOrNull()
+        ?: return matcher.matches(entry.level.letter.toString())
+
+    val minimum = LogLevel.fromToken(literal) ?: return false
+    return entry.level.ordinal >= minimum.ordinal
+}
+
+/**
+ * An unprivileged app can only speak for its own package, so any literal is checked against this
+ * app's package name and then narrowed to this app's records. `package:mine` skips the name check.
+ */
+private fun LogFilter.Field.matchesPackage(
+    entry: LogEntry,
+    context: LogFilterContext,
+): Boolean {
+    val isOwnRecord = entry.pid == context.ownPid
+    val literal = matcher.literalOrNull() ?: return isOwnRecord && matcher.matches(context.ownPackageName)
+
+    if (literal.equals(MINE, ignoreCase = true)) return isOwnRecord
+
+    return isOwnRecord && matcher.matches(context.ownPackageName)
+}
+
+private fun ValueMatcher.literalOrNull(): String? =
+    when (this) {
+        is ValueMatcher.Substring -> value
+        is ValueMatcher.Exact -> value
+        is ValueMatcher.Pattern -> null
+    }
+
+internal const val MINE = "mine"

--- a/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogFilterParser.kt
+++ b/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogFilterParser.kt
@@ -1,0 +1,146 @@
+package com.flixclusive.feature.mobile.settings.screen.system.logcat
+
+internal data class ParsedFilter(
+    val filter: LogFilter,
+    val error: String? = null,
+)
+
+/**
+ * Parses the Android-Studio-style filter query. It never throws: the user is typing, so a half
+ * written query has to degrade into something that still shows rows rather than blanking the list.
+ * Anything it cannot make sense of becomes a plain substring term and is reported through
+ * [ParsedFilter.error].
+ */
+internal object LogFilterParser {
+    private const val REGEX_OPERATOR = '~'
+    private const val NEGATION = '-'
+    private const val QUOTE = '"'
+    private const val ESCAPE = '\\'
+
+    fun parse(query: String): ParsedFilter {
+        val (rawTerms, unterminatedQuote) = splitTerms(query)
+        if (rawTerms.isEmpty()) {
+            return ParsedFilter(LogFilter.MatchAll, error = unterminatedQuote.errorOrNull())
+        }
+
+        var error: String? = unterminatedQuote.errorOrNull()
+        val terms = rawTerms.map { raw ->
+            val parsed = parseTerm(raw)
+            if (error == null) error = parsed.error
+            parsed.filter
+        }
+
+        val filter = if (terms.size == 1) terms.first() else LogFilter.And(terms)
+        return ParsedFilter(filter, error = error)
+    }
+
+    private fun Boolean.errorOrNull() = if (this) "Unterminated quote" else null
+
+    private fun splitTerms(query: String): Pair<List<String>, Boolean> {
+        val terms = mutableListOf<String>()
+        val current = StringBuilder()
+        var inQuote = false
+        var escaped = false
+
+        query.forEach { char ->
+            when {
+                escaped -> {
+                    current.append(char)
+                    escaped = false
+                }
+
+                char == ESCAPE && inQuote -> {
+                    current.append(char)
+                    escaped = true
+                }
+
+                char == QUOTE -> {
+                    current.append(char)
+                    inQuote = !inQuote
+                }
+
+                char.isWhitespace() && !inQuote -> {
+                    if (current.isNotEmpty()) {
+                        terms += current.toString()
+                        current.clear()
+                    }
+                }
+
+                else -> current.append(char)
+            }
+        }
+
+        if (current.isNotEmpty()) terms += current.toString()
+        return terms to inQuote
+    }
+
+    private fun parseTerm(raw: String): ParsedFilter {
+        val negated = raw.length > 1 && raw[0] == NEGATION
+        val body = if (negated) raw.substring(1) else raw
+
+        val parsed = parseUnsignedTerm(body)
+        val filter = if (negated) LogFilter.Not(parsed.filter) else parsed.filter
+        return ParsedFilter(filter, error = parsed.error)
+    }
+
+    private fun parseUnsignedTerm(body: String): ParsedFilter {
+        val quoteIndex = body.indexOf(QUOTE)
+        val colonIndex = body.indexOf(':')
+        val hasFieldSeparator = colonIndex > 0 && (quoteIndex == -1 || colonIndex < quoteIndex)
+
+        if (hasFieldSeparator) {
+            val isRegex = body[colonIndex - 1] == REGEX_OPERATOR
+            val keyToken = body.substring(0, if (isRegex) colonIndex - 1 else colonIndex)
+            val key = FilterKey.fromToken(keyToken)
+
+            if (key != null) {
+                val (matcher, error) = toMatcher(body.substring(colonIndex + 1), isRegex = isRegex)
+                return ParsedFilter(LogFilter.Field(key, matcher), error = error)
+            }
+        }
+
+        val (matcher, error) = toMatcher(body, isRegex = false)
+        return ParsedFilter(LogFilter.Bare(matcher), error = error)
+    }
+
+    private fun toMatcher(
+        raw: String,
+        isRegex: Boolean,
+    ): Pair<ValueMatcher, String?> {
+        val isQuoted = raw.length >= 2 && raw.first() == QUOTE && raw.last() == QUOTE
+        val literal = when {
+            isQuoted -> unescape(raw.substring(1, raw.length - 1))
+            raw.startsWith(QUOTE) -> unescape(raw.substring(1))
+            else -> raw
+        }
+
+        if (isRegex) {
+            val regex = runCatching { Regex(literal) }.getOrNull()
+                ?: return ValueMatcher.Substring(literal) to "Invalid pattern: $literal"
+
+            return ValueMatcher.Pattern(regex) to null
+        }
+
+        return if (isQuoted) ValueMatcher.Exact(literal) to null else ValueMatcher.Substring(literal) to null
+    }
+
+    private fun unescape(value: String): String {
+        if (!value.contains(ESCAPE)) return value
+
+        val builder = StringBuilder(value.length)
+        var escaped = false
+        value.forEach { char ->
+            when {
+                escaped -> {
+                    builder.append(char)
+                    escaped = false
+                }
+
+                char == ESCAPE -> escaped = true
+                else -> builder.append(char)
+            }
+        }
+
+        return builder.toString()
+    }
+}

--- a/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogcatDataSource.kt
+++ b/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogcatDataSource.kt
@@ -1,0 +1,135 @@
+package com.flixclusive.feature.mobile.settings.screen.system.logcat
+
+import android.os.SystemClock
+import com.flixclusive.core.common.dispatchers.AppDispatchers
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.ProducerScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.launch
+import java.io.BufferedReader
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicLong
+import javax.inject.Inject
+
+internal class LogcatDataSource @Inject constructor(
+    private val appDispatchers: AppDispatchers,
+) {
+    val ownPid: Int = android.os.Process.myPid()
+
+    /** Kept across restarts of [stream] rather than reset per process. Ids seed the list keys and
+     * the clear marker, both of which break if a restarted stream starts numbering from zero again. */
+    private val sequence = AtomicLong(0L)
+
+    /**
+     * `readLine` is an uninterruptible blocking call, so the reading loop cannot be cancelled from
+     * the outside. [channelFlow] is what makes cancellation work: the builder body parks on the
+     * cancellable `join`, and unwinding it destroys the process, which closes the pipe and drops the
+     * blocked read out with EOF. A plain `flow { }` would leave both the process and its thread
+     * behind forever.
+     */
+    fun stream(): Flow<List<LogEntry>> =
+        channelFlow {
+            val process = startProcess()
+            val pump = launch(appDispatchers.io) { pump(process) }
+
+            try {
+                pump.join()
+            } finally {
+                process.destroy()
+            }
+        }
+
+    private fun startProcess(): Process =
+        try {
+            newProcess(seeded = true)
+        } catch (_: IOException) {
+            newProcess(seeded = false)
+        }
+
+    private fun newProcess(seeded: Boolean): Process {
+        val command = buildList {
+            add(LOGCAT)
+            add("-v")
+            add("threadtime")
+            if (seeded) {
+                add("-T")
+                add(SEED_LINES.toString())
+            }
+        }
+
+        return ProcessBuilder(command)
+            .redirectErrorStream(true)
+            .start()
+    }
+
+    private suspend fun ProducerScope<List<LogEntry>>.pump(process: Process) {
+        var previous: LogEntry? = null
+        val batch = ArrayList<LogEntry>(MAX_BATCH)
+        var lastFlush = SystemClock.uptimeMillis()
+
+        try {
+            process.inputStream.bufferedReader().buffered(READ_BUFFER_BYTES).use { reader ->
+                while (true) {
+                    currentCoroutineContext().ensureActive()
+
+                    if (batch.shouldFlush(reader, lastFlush)) {
+                        send(ArrayList(batch))
+                        batch.clear()
+                        lastFlush = SystemClock.uptimeMillis()
+                    }
+
+                    val raw = reader.readLine() ?: break
+                    val entry = LogcatParser.parse(
+                        raw = raw,
+                        id = sequence.get(),
+                        previous = previous,
+                    )
+
+                    if (entry != null) {
+                        previous = entry
+                        sequence.incrementAndGet()
+                        batch += entry
+                    }
+                }
+
+                if (batch.isNotEmpty()) send(ArrayList(batch))
+            }
+        } catch (exception: IOException) {
+            // The stream dies with an IOException when the process is destroyed on cancellation,
+            // which is the normal shutdown path rather than a failure worth surfacing.
+            currentCoroutineContext().ensureActive()
+            throw exception
+        } catch (exception: CancellationException) {
+            throw exception
+        }
+    }
+
+    /**
+     * `ready()` does the coalescing for free: a burst piles into one batch while an idle stream
+     * flushes its tail straight away. The ceiling keeps the list moving during a sustained torrent.
+     */
+    private fun List<LogEntry>.shouldFlush(
+        reader: BufferedReader,
+        lastFlush: Long,
+    ): Boolean {
+        if (isEmpty()) return false
+        if (size >= MAX_BATCH) return true
+
+        val elapsed = SystemClock.uptimeMillis() - lastFlush
+        if (elapsed >= MAX_FLUSH_MS) return true
+
+        return elapsed >= MIN_FLUSH_MS && !reader.ready()
+    }
+
+    private companion object {
+        const val LOGCAT = "logcat"
+        const val SEED_LINES = 500
+        const val MIN_FLUSH_MS = 120L
+        const val MAX_FLUSH_MS = 250L
+        const val MAX_BATCH = 300
+        const val READ_BUFFER_BYTES = 32 * 1024
+    }
+}

--- a/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogcatParser.kt
+++ b/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogcatParser.kt
@@ -1,0 +1,92 @@
+package com.flixclusive.feature.mobile.settings.screen.system.logcat
+
+internal object LogcatParser {
+    const val TAG_WIDTH = 23
+    const val MAX_LINE_CHARS = 2_000
+
+    private const val DIVIDER_PREFIX = "---------"
+    private const val ELLIPSIS = "…"
+
+    private val THREADTIME =
+        Regex(
+            """^(?:\d{4}-)?(\d{2}-\d{2})\s+(\d{2}:\d{2}:\d{2}\.\d{3})\s+(\d+)\s+(\d+)\s+([VDIWEFS])\s+(.*?)\s*:\s?(.*)$""",
+        )
+
+    /**
+     * [previous] is passed in rather than held as parser state so this stays a pure function. A line
+     * that carries no header is a continuation of the entry before it — a stack trace frame, say —
+     * and is emitted as its own entry rather than being folded into [previous]'s message, because a
+     * row renders exactly one line.
+     */
+    fun parse(
+        raw: String,
+        id: Long,
+        previous: LogEntry?,
+    ): LogEntry? {
+        if (raw.isBlank()) return null
+        if (raw.startsWith(DIVIDER_PREFIX)) return null
+
+        val match = THREADTIME.matchEntire(raw)
+        if (match == null) {
+            return previous?.let { continuationOf(it, id = id, message = raw.trim()) }
+        }
+
+        val (date, time, pid, tid, levelLetter, tag, message) = match.destructured
+        val level = LogLevel.fromLetter(levelLetter[0]) ?: return null
+        val truncated = message.truncate()
+
+        val prefix = buildPrefix(time = time, pid = pid, tid = tid, level = level, tag = tag)
+
+        return LogEntry(
+            id = id,
+            date = date,
+            time = time,
+            pid = pid.toIntOrNull() ?: return null,
+            tid = tid.toIntOrNull() ?: return null,
+            level = level,
+            tag = tag,
+            message = truncated,
+            isContinuation = false,
+            text = prefix + truncated,
+            messageStart = prefix.length,
+        )
+    }
+
+    private fun continuationOf(
+        previous: LogEntry,
+        id: Long,
+        message: String,
+    ): LogEntry {
+        val truncated = message.truncate()
+
+        return previous.copy(
+            id = id,
+            message = truncated,
+            isContinuation = true,
+            text = " ".repeat(previous.messageStart) + truncated,
+        )
+    }
+
+    private fun buildPrefix(
+        time: String,
+        pid: String,
+        tid: String,
+        level: LogLevel,
+        tag: String,
+    ): String =
+        buildString {
+            append(time)
+            append("  ")
+            append(pid)
+            append('-')
+            append(tid)
+            append("  ")
+            append(level.letter)
+            append("  ")
+            append(tag.take(TAG_WIDTH).padEnd(TAG_WIDTH))
+            append("  ")
+        }
+
+    private fun String.truncate(): String =
+        if (length <= MAX_LINE_CHARS) this else take(MAX_LINE_CHARS) + ELLIPSIS
+}

--- a/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogcatTweakScreen.kt
+++ b/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogcatTweakScreen.kt
@@ -1,0 +1,487 @@
+package com.flixclusive.feature.mobile.settings.screen.system.logcat
+
+import android.content.Intent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.flixclusive.core.common.domain.Async
+import com.flixclusive.core.common.domain.Async.Companion.AsyncAnimatedContent
+import com.flixclusive.core.navigation.navigator.NavigateBack
+import com.flixclusive.core.presentation.common.util.CustomClipboardManager.Companion.rememberClipboardManager
+import com.flixclusive.core.presentation.mobile.components.AdaptiveIcon
+import com.flixclusive.core.presentation.mobile.components.EmptyDataMessage
+import com.flixclusive.core.presentation.mobile.components.LoadingScreen
+import com.flixclusive.core.presentation.mobile.components.RetryButton
+import com.flixclusive.core.presentation.mobile.components.material3.PlainTooltipBox
+import com.flixclusive.core.presentation.mobile.components.material3.dialog.TextAlertDialog
+import com.flixclusive.core.presentation.mobile.components.material3.topbar.ActionButton
+import com.flixclusive.core.presentation.mobile.components.material3.topbar.CommonTopBarWithSearch
+import com.flixclusive.core.presentation.mobile.theme.FlixclusiveTheme
+import com.flixclusive.core.presentation.mobile.util.LocalGlobalScaffoldPadding
+import com.flixclusive.feature.mobile.settings.R
+import com.flixclusive.feature.mobile.settings.screen.system.logcat.component.LogcatActionsSheet
+import com.flixclusive.feature.mobile.settings.screen.system.logcat.component.LogcatFilterField
+import com.flixclusive.feature.mobile.settings.screen.system.logcat.component.LogcatFindBar
+import com.flixclusive.feature.mobile.settings.screen.system.logcat.component.LogcatRow
+import com.ramcosta.composedestinations.annotation.Destination
+import com.ramcosta.composedestinations.annotation.ExternalModuleGraph
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+import kotlin.math.abs
+import com.flixclusive.core.drawables.R as UiCommonR
+
+private val LogRowHeight = 18.dp
+private const val INSTANT_JUMP_THRESHOLD = 50
+private val EmptyLogcatUiState = LogcatUiState()
+
+@Destination<ExternalModuleGraph>
+@Composable
+internal fun LogcatTweakScreen(
+    navigator: NavigateBack,
+    viewModel: LogcatTweakViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val levelFilters by viewModel.levelFilters.collectAsStateWithLifecycle()
+    val isPaused by viewModel.isPaused.collectAsStateWithLifecycle()
+
+    LogcatTweakScreenContent(
+        state = state,
+        // Read once as the fields' seed values rather than collected as State — each field owns its
+        // own text after that, so neither query needs to be observed here.
+        initialFilterQuery = viewModel.filterQuery.value,
+        searchQuery = { viewModel.searchQuery.value },
+        levelFilters = levelFilters,
+        isPaused = isPaused,
+        onNavigateBack = navigator::navigateBack,
+        onFilterQueryChange = viewModel::onFilterQueryChange,
+        onSearchQueryChange = viewModel::onSearchQueryChange,
+        onToggleLevelFilter = viewModel::onToggleLevelFilter,
+        onTogglePause = viewModel::onTogglePause,
+        onClear = viewModel::onClear,
+        onReload = viewModel::onReload,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun LogcatTweakScreenContent(
+    state: Async<LogcatUiState>,
+    initialFilterQuery: String,
+    searchQuery: () -> String,
+    levelFilters: ImmutableSet<LogLevel>,
+    isPaused: Boolean,
+    onNavigateBack: () -> Unit,
+    onFilterQueryChange: (String) -> Unit,
+    onSearchQueryChange: (String) -> Unit,
+    onToggleLevelFilter: (LogLevel) -> Unit,
+    onTogglePause: () -> Unit,
+    onClear: () -> Unit,
+    onReload: () -> Unit,
+) {
+    val context = LocalContext.current
+    val clipboardManager = rememberClipboardManager()
+    val scope = rememberCoroutineScope()
+
+    val uiState = (state as? Async.Success)?.data ?: EmptyLogcatUiState
+
+    var isSearching by rememberSaveable { mutableStateOf(false) }
+    var isShowingActions by rememberSaveable { mutableStateOf(false) }
+    var isConfirmingClear by rememberSaveable { mutableStateOf(false) }
+    var currentMatch by rememberSaveable { mutableIntStateOf(0) }
+    var followTail by rememberSaveable { mutableStateOf(true) }
+
+    val listState = rememberLazyListState()
+    val horizontalScroll = rememberScrollState()
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+    val rowHeightPx = with(LocalDensity.current) { LogRowHeight.roundToPx() }
+
+    suspend fun jumpTo(ordinal: Int) {
+        val target = uiState.matchIndices.getOrNull(ordinal) ?: return
+        followTail = false
+
+        val centering = -(listState.layoutInfo.viewportSize.height / 2 - rowHeightPx / 2)
+        // Animating across thousands of rows is a multi-second crawl, so only near jumps animate.
+        if (abs(target - listState.firstVisibleItemIndex) > INSTANT_JUMP_THRESHOLD) {
+            listState.scrollToItem(target, centering)
+        } else {
+            listState.animateScrollToItem(target, centering)
+        }
+    }
+
+    // Keyed on the query alone, so an incoming batch cannot yank the list out from under the user.
+    // The state carries its query and its match indices from the same emission, so they always agree.
+    LaunchedEffect(uiState.searchQuery) {
+        currentMatch = 0
+        if (uiState.searchQuery.isNotEmpty()) jumpTo(0)
+    }
+
+    if (isConfirmingClear) {
+        TextAlertDialog(
+            title = stringResource(R.string.logcat_clear_confirm_title),
+            message = stringResource(R.string.logcat_clear_confirm_message),
+            confirmButtonLabel = stringResource(R.string.logcat_clear),
+            onConfirm = {
+                onClear()
+                isConfirmingClear = false
+            },
+            onDismiss = { isConfirmingClear = false },
+        )
+    }
+
+    if (isShowingActions) {
+        LogcatActionsSheet(
+            onDismissRequest = { isShowingActions = false },
+            onCopy = {
+                clipboardManager.setText(uiState.entries.joinToString("\n") { it.text })
+                isShowingActions = false
+            },
+            onShare = {
+                context.shareLogs(uiState.entries.joinToString("\n") { it.text })
+                isShowingActions = false
+            },
+            onClear = {
+                isShowingActions = false
+                isConfirmingClear = true
+            },
+        )
+    }
+
+    Scaffold(
+        contentWindowInsets = WindowInsets(),
+        topBar = {
+            CommonTopBarWithSearch(
+                title = stringResource(R.string.logcat),
+                isSearching = isSearching,
+                searchQuery = searchQuery,
+                onQueryChange = onSearchQueryChange,
+                onToggleSearchBar = {
+                    isSearching = it
+                    if (!it) onSearchQueryChange("")
+                },
+                onNavigate = onNavigateBack,
+                scrollBehavior = scrollBehavior,
+                extraActions = {
+                    PlainTooltipBox(
+                        description = stringResource(
+                            if (isPaused) R.string.logcat_resume else R.string.logcat_pause,
+                        ),
+                    ) {
+                        ActionButton(onClick = onTogglePause) {
+                            AdaptiveIcon(
+                                painter = painterResource(
+                                    if (isPaused) UiCommonR.drawable.play else UiCommonR.drawable.round_pause_24,
+                                ),
+                                contentDescription = stringResource(
+                                    if (isPaused) R.string.logcat_resume else R.string.logcat_pause,
+                                ),
+                                dp = 18.dp,
+                            )
+                        }
+                    }
+
+                    PlainTooltipBox(description = stringResource(R.string.logcat_more_actions)) {
+                        ActionButton(onClick = { isShowingActions = true }) {
+                            AdaptiveIcon(
+                                painter = painterResource(UiCommonR.drawable.more_vert),
+                                contentDescription = stringResource(R.string.logcat_more_actions),
+                                dp = 18.dp,
+                            )
+                        }
+                    }
+                },
+            )
+        },
+        modifier = Modifier
+            .padding(LocalGlobalScaffoldPadding.current)
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            // The top bar hides its extra actions while searching, so the find controls need a bar
+            // of their own rather than a slot up there.
+            AnimatedVisibility(visible = isSearching) {
+                LogcatFindBar(
+                    matchCount = uiState.matchIndices.size,
+                    currentMatch = currentMatch,
+                    onPrevious = {
+                        scope.launch {
+                            currentMatch = (currentMatch - 1).mod(uiState.matchIndices.size)
+                            jumpTo(currentMatch)
+                        }
+                    },
+                    onNext = {
+                        scope.launch {
+                            currentMatch = (currentMatch + 1).mod(uiState.matchIndices.size)
+                            jumpTo(currentMatch)
+                        }
+                    },
+                )
+            }
+
+            LogcatFilterField(
+                initialQuery = initialFilterQuery,
+                onQueryChange = onFilterQueryChange,
+                levelFilters = levelFilters,
+                onToggleLevelFilter = onToggleLevelFilter,
+                filterError = uiState.filterError,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+
+            HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
+
+            LogcatList(
+                state = state,
+                uiState = uiState,
+                listState = listState,
+                horizontalScroll = horizontalScroll,
+                currentMatchIndex = uiState.matchIndices.getOrNull(currentMatch),
+                followTail = followTail,
+                onFollowTailChange = { followTail = it },
+                onReload = onReload,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun LogcatList(
+    state: Async<LogcatUiState>,
+    uiState: LogcatUiState,
+    listState: LazyListState,
+    horizontalScroll: ScrollState,
+    currentMatchIndex: Int?,
+    followTail: Boolean,
+    onFollowTailChange: (Boolean) -> Unit,
+    onReload: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val scope = rememberCoroutineScope()
+    val measurer = rememberTextMeasurer()
+    val logStyle = remember {
+        TextStyle(fontFamily = FontFamily.Monospace, fontSize = 11.sp, lineHeight = 15.sp)
+    }
+    val charWidthPx = remember(logStyle) { measurer.measure("0", logStyle).size.width }
+
+    val highlightColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.35f)
+    val matchStyle = remember(highlightColor) { SpanStyle(background = highlightColor) }
+
+    val isAtBottom by remember {
+        derivedStateOf {
+            val info = listState.layoutInfo
+            info.totalItemsCount == 0 ||
+                info.visibleItemsInfo.lastOrNull()?.index == info.totalItemsCount - 1
+        }
+    }
+
+    val setFollowTail by rememberUpdatedState(onFollowTailChange)
+
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.lastScrolledBackward }
+            .filter { it }
+            .collect { setFollowTail(false) }
+    }
+
+    LaunchedEffect(listState) {
+        snapshotFlow { isAtBottom }
+            .filter { it }
+            .collect { setFollowTail(true) }
+    }
+
+    // scrollToItem rather than animateScrollToItem: with a batch arriving every ~150ms an animation
+    // would be cancelled before finishing and the list would crawl instead of keeping up.
+    LaunchedEffect(uiState.entries.lastOrNull()?.id, followTail) {
+        if (followTail && uiState.entries.isNotEmpty()) {
+            listState.scrollToItem(uiState.entries.lastIndex)
+        }
+    }
+
+    Box(modifier = modifier) {
+        AsyncAnimatedContent(
+            targetState = state,
+            modifier = Modifier.fillMaxSize(),
+            loadingContent = { LoadingScreen(modifier = Modifier.fillMaxSize()) },
+            errorContent = {
+                RetryButton(
+                    modifier = Modifier.fillMaxSize(),
+                    error = it.message.asString(),
+                    onRetry = onReload,
+                )
+            },
+        ) { stateProvider ->
+            val logs = stateProvider()
+
+            if (logs.entries.isEmpty()) {
+                EmptyDataMessage(
+                    modifier = Modifier.fillMaxSize(),
+                    emojiHeader = "🪵",
+                    title = stringResource(R.string.logcat_empty_title),
+                    description = stringResource(R.string.logcat_empty_description),
+                )
+            } else {
+                BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                    // Every row is measured at this one width. Sharing a ScrollState across N rows
+                    // means N nodes write its extent during measure, so they have to agree or the
+                    // shared offset flips between the longest and shortest visible line each frame.
+                    val rowWidth = with(LocalDensity.current) {
+                        maxOf((charWidthPx * logs.maxLineLength).toDp(), maxWidth)
+                    }
+
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier.fillMaxSize(),
+                    ) {
+                        items(
+                            items = logs.entries,
+                            key = { it.id },
+                            contentType = { "log" },
+                        ) { entry ->
+                            LogcatRow(
+                                entry = entry,
+                                searchQuery = logs.searchQuery,
+                                isCurrentMatch = currentMatchIndex != null &&
+                                    logs.entries.getOrNull(currentMatchIndex)?.id == entry.id,
+                                style = logStyle,
+                                width = rowWidth,
+                                height = LogRowHeight,
+                                horizontalScroll = horizontalScroll,
+                                matchStyle = matchStyle,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        AnimatedVisibility(
+            visible = !followTail,
+            enter = scaleIn() + fadeIn(),
+            exit = scaleOut() + fadeOut(),
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp),
+        ) {
+            PlainTooltipBox(description = stringResource(R.string.logcat_scroll_to_latest)) {
+                ActionButton(
+                    onClick = {
+                        onFollowTailChange(true)
+                        scope.launch {
+                            if (uiState.entries.isNotEmpty()) {
+                                listState.scrollToItem(uiState.entries.lastIndex)
+                            }
+                        }
+                    },
+                    backgroundColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                ) {
+                    AdaptiveIcon(
+                        painter = painterResource(UiCommonR.drawable.down_arrow),
+                        contentDescription = stringResource(R.string.logcat_scroll_to_latest),
+                        dp = 18.dp,
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun android.content.Context.shareLogs(logs: String) {
+    val intent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_SUBJECT, getString(R.string.logcat_share_title))
+        putExtra(Intent.EXTRA_TEXT, logs)
+    }
+
+    startActivity(Intent.createChooser(intent, getString(R.string.logcat_share)))
+}
+
+@Preview
+@Composable
+private fun LogcatTweakScreenPreview() {
+    val entries = List(30) { index ->
+        val level = LogLevel.entries[index % LogLevel.entries.size]
+        LogcatParser.parse(
+            raw = "06-14 09:12:3$index.123  1234  1256 ${level.letter} Flixclusive: sample line $index",
+            id = index.toLong(),
+            previous = null,
+        )!!
+    }
+
+    FlixclusiveTheme {
+        Surface {
+            LogcatTweakScreenContent(
+                state = Async.Success(
+                    LogcatUiState(
+                        entries = entries.toPersistentList(),
+                        maxLineLength = entries.maxOf { it.text.length },
+                        totalCount = entries.size,
+                    ),
+                ),
+                initialFilterQuery = LogcatTweakViewModel.DEFAULT_FILTER_QUERY,
+                searchQuery = { "" },
+                levelFilters = persistentSetOf(),
+                isPaused = false,
+                onNavigateBack = {},
+                onFilterQueryChange = {},
+                onSearchQueryChange = {},
+                onToggleLevelFilter = {},
+                onTogglePause = {},
+                onClear = {},
+                onReload = {},
+            )
+        }
+    }
+}

--- a/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogcatTweakViewModel.kt
+++ b/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogcatTweakViewModel.kt
@@ -1,0 +1,215 @@
+package com.flixclusive.feature.mobile.settings.screen.system.logcat
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.flixclusive.core.common.dispatchers.AppDispatchers
+import com.flixclusive.core.common.domain.Async
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentSet
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.scan
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
+
+@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+@HiltViewModel
+internal class LogcatTweakViewModel @Inject constructor(
+    private val logcatDataSource: LogcatDataSource,
+    private val appDispatchers: AppDispatchers,
+    @ApplicationContext context: Context,
+) : ViewModel() {
+    private val filterContext = LogFilterContext(
+        ownPid = logcatDataSource.ownPid,
+        ownPackageName = context.packageName,
+    )
+
+    private val _filterQuery = MutableStateFlow(DEFAULT_FILTER_QUERY)
+    val filterQuery = _filterQuery.asStateFlow()
+
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery = _searchQuery.asStateFlow()
+
+    private val _levelFilters = MutableStateFlow<ImmutableSet<LogLevel>>(persistentSetOf())
+    val levelFilters = _levelFilters.asStateFlow()
+
+    private val _isPaused = MutableStateFlow(false)
+    val isPaused = _isPaused.asStateFlow()
+
+    /** Clearing hides everything logged so far rather than running `logcat -c`, which wipes a buffer
+     * shared with the rest of the system and can fail without saying so. */
+    private val clearedBeforeId = MutableStateFlow(NOTHING_CLEARED)
+
+    /** Bumped by [onReload] to resubscribe after a failure. The catch below terminates the flow, so
+     * without a fresh subscription the error state would be permanent. */
+    private val retryTrigger = MutableStateFlow(0)
+
+    /** Debounced separately from the combine below so its [stateIn] can seed an immediate value —
+     * debouncing inside the combine would delay the very first emission too, since `combine` waits
+     * on every source's first value. */
+    private val debouncedFilter = _filterQuery
+        .debounce(FILTER_DEBOUNCE)
+        .distinctUntilChanged()
+        .map(LogFilterParser::parse)
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Lazily,
+            initialValue = LogFilterParser.parse(_filterQuery.value),
+        )
+
+    private val debouncedSearch = _searchQuery
+        .debounce(SEARCH_DEBOUNCE)
+        .distinctUntilChanged()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Lazily,
+            initialValue = _searchQuery.value,
+        )
+
+    private val rawEntries: StateFlow<Async<List<LogEntry>>> = retryTrigger
+        .flatMapLatest {
+            logcatDataSource
+                .stream()
+                .scan(ArrayDeque<LogEntry>(BUFFER_CAPACITY)) { buffer, batch ->
+                    buffer.addAll(batch)
+                    while (buffer.size > BUFFER_CAPACITY) buffer.removeFirst()
+                    buffer
+                }
+                // Hands downstream an immutable snapshot so the mutable deque is never read from
+                // another dispatcher.
+                .map { Async.Success(ArrayList(it)) as Async<List<LogEntry>> }
+                .onStart { emit(Async.Loading) }
+                .catch { emit(Async.Failure(it)) }
+        }.flowOn(appDispatchers.default)
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT_MS),
+            initialValue = Async.Loading,
+        )
+
+    /** Pausing freezes the view without losing anything: this still collects [rawEntries] while
+     * paused — dropping the subscription would let the WhileSubscribed timeout kill the logcat
+     * process and reset the buffer — it just keeps handing the last unpaused snapshot downstream. */
+    private val displayedEntries = rawEntries
+        .combine(_isPaused) { entries, paused -> entries to paused }
+        .scan(Async.Loading as Async<List<LogEntry>>) { previous, (entries, paused) ->
+            if (paused) previous else entries
+        }.distinctUntilChanged()
+
+    private val criteria = combine(
+        debouncedFilter,
+        debouncedSearch,
+        _levelFilters,
+        clearedBeforeId,
+        ::Criteria,
+    )
+
+    val state: StateFlow<Async<LogcatUiState>> = combine(displayedEntries, criteria) { entries, criteria ->
+        when (entries) {
+            is Async.Loading -> Async.Loading
+            is Async.Failure -> entries
+            is Async.Success -> Async.Success(entries.data.toUiState(criteria))
+        }
+    }.flowOn(appDispatchers.default)
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT_MS),
+            initialValue = Async.Loading,
+        )
+
+    fun onFilterQueryChange(value: String) {
+        _filterQuery.value = value
+    }
+
+    fun onSearchQueryChange(value: String) {
+        _searchQuery.value = value
+    }
+
+    fun onToggleLevelFilter(level: LogLevel) {
+        _levelFilters.update { current ->
+            if (level in current) {
+                (current - level).toPersistentSet()
+            } else {
+                (current + level).toPersistentSet()
+            }
+        }
+    }
+
+    fun onTogglePause() {
+        _isPaused.update { !it }
+    }
+
+    fun onClear() {
+        val entries = (rawEntries.value as? Async.Success)?.data
+        clearedBeforeId.value = entries?.lastOrNull()?.id ?: NOTHING_CLEARED
+    }
+
+    fun onReload() {
+        retryTrigger.update { it + 1 }
+    }
+
+    private fun List<LogEntry>.toUiState(criteria: Criteria): LogcatUiState {
+        val filter = criteria.parsed.filter
+        val visible = ArrayList<LogEntry>(size)
+        val matches = ArrayList<Int>()
+        var maxLineLength = 0
+
+        forEach { entry ->
+            if (entry.id <= criteria.clearedBeforeId) return@forEach
+            if (criteria.levels.isNotEmpty() && entry.level !in criteria.levels) return@forEach
+            if (!filter.matches(entry, filterContext)) return@forEach
+
+            if (criteria.search.isNotEmpty() && entry.text.contains(criteria.search, ignoreCase = true)) {
+                matches += visible.size
+            }
+
+            visible += entry
+            if (entry.text.length > maxLineLength) maxLineLength = entry.text.length
+        }
+
+        return LogcatUiState(
+            entries = visible.toPersistentList(),
+            matchIndices = matches.toPersistentList(),
+            maxLineLength = maxLineLength,
+            searchQuery = criteria.search,
+            totalCount = size,
+            filterError = criteria.parsed.error,
+        )
+    }
+
+    private data class Criteria(
+        val parsed: ParsedFilter,
+        val search: String,
+        val levels: ImmutableSet<LogLevel>,
+        val clearedBeforeId: Long,
+    )
+
+    companion object {
+        const val DEFAULT_FILTER_QUERY = "package:mine "
+
+        private const val NOTHING_CLEARED = -1L
+        private const val BUFFER_CAPACITY = 5_000
+        private const val SUBSCRIPTION_TIMEOUT_MS = 5_000L
+        private val FILTER_DEBOUNCE = 250.milliseconds
+        private val SEARCH_DEBOUNCE = 250.milliseconds
+    }
+}

--- a/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogcatUiState.kt
+++ b/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogcatUiState.kt
@@ -1,0 +1,20 @@
+package com.flixclusive.feature.mobile.settings.screen.system.logcat
+
+import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+/**
+ * [entries], [matchIndices] and [maxLineLength] are produced together in a single mapping step.
+ * They have to be: indices that arrive separately from the list they point into can be read between
+ * two recompositions and index out of bounds.
+ */
+@Immutable
+internal data class LogcatUiState(
+    val entries: ImmutableList<LogEntry> = persistentListOf(),
+    val matchIndices: ImmutableList<Int> = persistentListOf(),
+    val maxLineLength: Int = 0,
+    val searchQuery: String = "",
+    val totalCount: Int = 0,
+    val filterError: String? = null,
+)

--- a/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/component/LogcatActionsSheet.kt
+++ b/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/component/LogcatActionsSheet.kt
@@ -1,0 +1,110 @@
+package com.flixclusive.feature.mobile.settings.screen.system.logcat.component
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flixclusive.core.presentation.mobile.components.AdaptiveIcon
+import com.flixclusive.core.presentation.mobile.components.material3.CommonBottomSheet
+import com.flixclusive.core.presentation.mobile.theme.FlixclusiveTheme
+import com.flixclusive.core.presentation.mobile.util.AdaptiveSizeUtil.getAdaptiveDp
+import com.flixclusive.feature.mobile.settings.R
+import com.flixclusive.core.drawables.R as UiCommonR
+
+@Composable
+internal fun LogcatActionsSheet(
+    onDismissRequest: () -> Unit,
+    onCopy: () -> Unit,
+    onShare: () -> Unit,
+    onClear: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    CommonBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+    ) {
+        Column(modifier = Modifier.padding(bottom = 16.dp)) {
+            SheetAction(
+                iconId = UiCommonR.drawable.round_content_copy_24,
+                label = stringResource(R.string.logcat_copy),
+                onClick = onCopy,
+            )
+
+            SheetAction(
+                iconId = UiCommonR.drawable.share,
+                label = stringResource(R.string.logcat_share),
+                onClick = onShare,
+            )
+
+            SheetAction(
+                iconId = UiCommonR.drawable.delete,
+                label = stringResource(R.string.logcat_clear),
+                tint = MaterialTheme.colorScheme.error,
+                onClick = onClear,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SheetAction(
+    @DrawableRes iconId: Int,
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    tint: Color = LocalContentColor.current,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(min = getAdaptiveDp(52.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 20.dp),
+    ) {
+        AdaptiveIcon(
+            painter = painterResource(iconId),
+            contentDescription = null,
+            tint = tint,
+            dp = 20.dp,
+        )
+
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = tint,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun LogcatActionsSheetPreview() {
+    FlixclusiveTheme {
+        Surface {
+            LogcatActionsSheet(
+                onDismissRequest = {},
+                onCopy = {},
+                onShare = {},
+                onClear = {},
+            )
+        }
+    }
+}

--- a/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/component/LogcatFilterField.kt
+++ b/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/component/LogcatFilterField.kt
@@ -1,0 +1,156 @@
+package com.flixclusive.feature.mobile.settings.screen.system.logcat.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flixclusive.core.presentation.common.extensions.toTextFieldValue
+import com.flixclusive.core.presentation.mobile.components.AdaptiveIcon
+import com.flixclusive.core.presentation.mobile.components.material3.CustomOutlinedTextField
+import com.flixclusive.core.presentation.mobile.components.material3.topbar.ActionButton
+import com.flixclusive.core.presentation.mobile.theme.FlixclusiveTheme
+import com.flixclusive.feature.mobile.settings.R
+import com.flixclusive.feature.mobile.settings.component.AnimatedFilterChip
+import com.flixclusive.feature.mobile.settings.screen.system.logcat.LogLevel
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentSetOf
+import com.flixclusive.core.drawables.R as UiCommonR
+import com.flixclusive.core.strings.R as LocaleR
+
+@Composable
+internal fun LogcatFilterField(
+    initialQuery: String,
+    onQueryChange: (String) -> Unit,
+    levelFilters: ImmutableSet<LogLevel>,
+    onToggleLevelFilter: (LogLevel) -> Unit,
+    filterError: String?,
+    modifier: Modifier = Modifier,
+) {
+    // Seeded once; the field owns its text afterwards, so the query never has to be observed here.
+    val textFieldValue = remember { mutableStateOf(initialQuery.toTextFieldValue()) }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        CustomOutlinedTextField(
+            value = textFieldValue.value,
+            onValueChange = {
+                textFieldValue.value = it
+                onQueryChange(it.text)
+            },
+            singleLine = true,
+            isError = filterError != null,
+            textStyle = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+            leadingIcon = {
+                AdaptiveIcon(
+                    painter = painterResource(UiCommonR.drawable.filter_list),
+                    contentDescription = stringResource(R.string.logcat_filter_label),
+                    dp = 18.dp,
+                )
+            },
+            trailingIcon = {
+                AnimatedVisibility(
+                    visible = textFieldValue.value.text.isNotEmpty(),
+                    enter = scaleIn(),
+                    exit = scaleOut(),
+                ) {
+                    ActionButton(
+                        onClick = {
+                            textFieldValue.value = "".toTextFieldValue()
+                            onQueryChange("")
+                        },
+                    ) {
+                        AdaptiveIcon(
+                            painter = painterResource(UiCommonR.drawable.round_close_24),
+                            contentDescription = stringResource(LocaleR.string.close),
+                            tint = LocalContentColor.current.copy(0.6f),
+                        )
+                    }
+                }
+            },
+            placeholder = {
+                Text(
+                    text = stringResource(R.string.logcat_filter_hint),
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                    color = LocalContentColor.current.copy(0.5f),
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1,
+                )
+            },
+            supportingText = filterError?.let {
+                {
+                    Text(
+                        text = stringResource(R.string.logcat_filter_invalid),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp),
+        )
+
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            items(SELECTABLE_LEVELS, key = { it.name }) { level ->
+                AnimatedFilterChip(
+                    selected = level in levelFilters,
+                    label = level.name.take(1) + level.name.drop(1).lowercase(),
+                    onClick = { onToggleLevelFilter(level) },
+                )
+            }
+        }
+    }
+}
+
+private val SELECTABLE_LEVELS = listOf(
+    LogLevel.VERBOSE,
+    LogLevel.DEBUG,
+    LogLevel.INFO,
+    LogLevel.WARN,
+    LogLevel.ERROR,
+)
+
+@Preview
+@Composable
+private fun LogcatFilterFieldPreview() {
+    FlixclusiveTheme {
+        Surface {
+            LogcatFilterField(
+                initialQuery = "package:mine level:W",
+                onQueryChange = {},
+                levelFilters = persistentSetOf(LogLevel.ERROR),
+                onToggleLevelFilter = {},
+                filterError = null,
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
+        }
+    }
+}

--- a/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/component/LogcatFindBar.kt
+++ b/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/component/LogcatFindBar.kt
@@ -1,0 +1,89 @@
+package com.flixclusive.feature.mobile.settings.screen.system.logcat.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flixclusive.core.presentation.mobile.components.AdaptiveIcon
+import com.flixclusive.core.presentation.mobile.components.material3.PlainTooltipBox
+import com.flixclusive.core.presentation.mobile.components.material3.topbar.ActionButton
+import com.flixclusive.core.presentation.mobile.theme.FlixclusiveTheme
+import com.flixclusive.feature.mobile.settings.R
+import com.flixclusive.core.drawables.R as UiCommonR
+
+@Composable
+internal fun LogcatFindBar(
+    matchCount: Int,
+    currentMatch: Int,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val hasMatches = matchCount > 0
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.End,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp),
+    ) {
+        Text(
+            text = if (hasMatches) {
+                stringResource(R.string.logcat_match_format, currentMatch + 1, matchCount)
+            } else {
+                stringResource(R.string.logcat_no_matches)
+            },
+            style = MaterialTheme.typography.labelSmall.copy(fontFamily = FontFamily.Monospace),
+            color = LocalContentColor.current.copy(alpha = if (hasMatches) 0.8f else 0.5f),
+        )
+
+        PlainTooltipBox(description = stringResource(R.string.logcat_find_previous)) {
+            ActionButton(onClick = onPrevious, enabled = hasMatches) {
+                AdaptiveIcon(
+                    painter = painterResource(UiCommonR.drawable.up_arrow),
+                    contentDescription = stringResource(R.string.logcat_find_previous),
+                    dp = 18.dp,
+                )
+            }
+        }
+
+        PlainTooltipBox(description = stringResource(R.string.logcat_find_next)) {
+            ActionButton(onClick = onNext, enabled = hasMatches) {
+                AdaptiveIcon(
+                    painter = painterResource(UiCommonR.drawable.down_arrow),
+                    contentDescription = stringResource(R.string.logcat_find_next),
+                    dp = 18.dp,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun LogcatFindBarPreview() {
+    FlixclusiveTheme {
+        Surface {
+            LogcatFindBar(
+                matchCount = 17,
+                currentMatch = 2,
+                onPrevious = {},
+                onNext = {},
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
+        }
+    }
+}

--- a/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/component/LogcatRow.kt
+++ b/feature/mobile/settings/src/main/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/component/LogcatRow.kt
@@ -1,0 +1,139 @@
+package com.flixclusive.feature.mobile.settings.screen.system.logcat.component
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.flixclusive.core.presentation.mobile.theme.FlixclusiveTheme
+import com.flixclusive.feature.mobile.settings.screen.system.logcat.LogEntry
+import com.flixclusive.feature.mobile.settings.screen.system.logcat.LogLevel
+import com.flixclusive.feature.mobile.settings.screen.system.logcat.LogcatParser
+
+/**
+ * Every row shares one [horizontalScroll] state and one explicit [width]. Both are required:
+ * the shared state is what makes the rows pan together, and the identical width is what stops the
+ * N scroll nodes writing conflicting extents for that one state on every frame.
+ */
+@Composable
+internal fun LogcatRow(
+    entry: LogEntry,
+    searchQuery: String,
+    isCurrentMatch: Boolean,
+    style: TextStyle,
+    width: Dp,
+    height: Dp,
+    horizontalScroll: ScrollState,
+    matchStyle: SpanStyle,
+    modifier: Modifier = Modifier,
+) {
+    val display = remember(entry.id, searchQuery, matchStyle) {
+        entry.text.highlightOccurrences(query = searchQuery, style = matchStyle)
+    }
+
+    val currentMatchColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.22f)
+
+    Box(
+        contentAlignment = Alignment.CenterStart,
+        modifier = modifier
+            .height(height)
+            .horizontalScroll(horizontalScroll),
+    ) {
+        Text(
+            text = display,
+            style = style,
+            color = entry.level.color(),
+            softWrap = false,
+            maxLines = 1,
+            overflow = TextOverflow.Clip,
+            modifier = Modifier
+                .width(width)
+                .then(if (isCurrentMatch) Modifier.background(currentMatchColor) else Modifier),
+        )
+    }
+}
+
+@Composable
+private fun LogLevel.color(): Color =
+    when (this) {
+        LogLevel.WARN -> MaterialTheme.colorScheme.tertiary
+        LogLevel.ERROR, LogLevel.ASSERT -> MaterialTheme.colorScheme.error
+        LogLevel.INFO -> LocalContentColor.current.copy(alpha = 0.9f)
+        LogLevel.DEBUG -> LocalContentColor.current.copy(alpha = 0.65f)
+        LogLevel.VERBOSE, LogLevel.SILENT -> LocalContentColor.current.copy(alpha = 0.45f)
+    }
+
+internal fun String.highlightOccurrences(
+    query: String,
+    style: SpanStyle,
+): AnnotatedString {
+    if (query.isEmpty()) return AnnotatedString(this)
+
+    val source = this
+    var index = source.indexOf(query, ignoreCase = true)
+    if (index < 0) return AnnotatedString(source)
+
+    return buildAnnotatedString {
+        append(source)
+        while (index >= 0) {
+            addStyle(style, index, index + query.length)
+            index = source.indexOf(query, startIndex = index + query.length, ignoreCase = true)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun LogcatRowPreview() {
+    val entries = LogLevel.entries.mapIndexed { index, level ->
+        LogcatParser.parse(
+            raw = "06-14 09:12:33.123  1234  1256 ${level.letter} Flixclusive: sample ${level.name} line",
+            id = index.toLong(),
+            previous = null,
+        )!!
+    }
+
+    val scroll = rememberScrollState()
+    val style = TextStyle(fontFamily = FontFamily.Monospace, fontSize = 11.sp, lineHeight = 15.sp)
+
+    FlixclusiveTheme {
+        Surface {
+            Column {
+                entries.forEach { entry ->
+                    LogcatRow(
+                        entry = entry,
+                        searchQuery = "sample",
+                        isCurrentMatch = entry.level == LogLevel.ERROR,
+                        style = style,
+                        width = 600.dp,
+                        height = 18.dp,
+                        horizontalScroll = scroll,
+                        matchStyle = SpanStyle(background = MaterialTheme.colorScheme.primary.copy(alpha = 0.35f)),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/mobile/settings/src/main/res/values/strings.xml
+++ b/feature/mobile/settings/src/main/res/values/strings.xml
@@ -15,4 +15,28 @@
     <string name="label_dead">dead</string>
     <string name="label_alive">alive</string>
     <string name="label_total_format">%1$d total</string>
+    <!-- Logcat viewer -->
+    <string name="logcat_group_title">Debug</string>
+    <string name="logcat">Logcat</string>
+    <string name="logcat_content_desc">View, filter and search the app\'s live log output.</string>
+    <string name="logcat_filter_label">Filter</string>
+    <string name="logcat_filter_hint">package:mine level:E -tag:Foo</string>
+    <string name="logcat_filter_invalid">Some of this filter could not be read, so it was matched as plain text.</string>
+    <string name="logcat_match_format">%1$d/%2$d</string>
+    <string name="logcat_no_matches">No matches</string>
+    <string name="logcat_find_previous">Previous match</string>
+    <string name="logcat_find_next">Next match</string>
+    <string name="logcat_scroll_to_latest">Jump to latest</string>
+    <string name="logcat_more_actions">More actions</string>
+    <string name="logcat_pause">Pause</string>
+    <string name="logcat_resume">Resume</string>
+    <string name="logcat_copy">Copy visible logs</string>
+    <string name="logcat_share">Share visible logs</string>
+    <string name="logcat_share_title">App logs</string>
+    <string name="logcat_clear">Clear</string>
+    <string name="logcat_clear_confirm_title">Clear the log view?</string>
+    <string name="logcat_clear_confirm_message">Everything logged so far is hidden from this screen. New lines keep coming in, and nothing is deleted from the system log.</string>
+    <string name="logcat_empty_title">Nothing logged yet</string>
+    <string name="logcat_empty_description">Lines appear here as the app writes them. Loosen the filter if you expected output.</string>
+    <string name="logcat_count_format">%1$d of %2$d lines</string>
 </resources>

--- a/feature/mobile/settings/src/test/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogFilterMatchTest.kt
+++ b/feature/mobile/settings/src/test/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogFilterMatchTest.kt
@@ -1,0 +1,110 @@
+package com.flixclusive.feature.mobile.settings.screen.system.logcat
+
+import org.junit.Test
+import strikt.api.expectThat
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
+
+class LogFilterMatchTest {
+    private val context = LogFilterContext(ownPid = 1234, ownPackageName = "com.flixclusive")
+
+    private fun entry(
+        pid: Int = 1234,
+        tid: Int = 1256,
+        level: LogLevel = LogLevel.DEBUG,
+        tag: String = "Foo",
+        message: String = "body",
+    ) = LogcatParser.parse(
+        raw = "06-14 09:12:33.123  $pid  $tid ${level.letter} $tag: $message",
+        id = 0L,
+        previous = null,
+    )!!
+
+    private fun matches(
+        query: String,
+        entry: LogEntry,
+    ) = LogFilterParser.parse(query).filter.matches(entry, context)
+
+    @Test
+    fun `should match a tag case-insensitively`() {
+        expectThat(matches("tag:foo", entry(tag = "Foo"))).isTrue()
+    }
+
+    @Test
+    fun `should require a full match for a quoted tag`() {
+        expectThat(matches("""tag:"foo"""", entry(tag = "Foo"))).isTrue()
+        expectThat(matches("""tag:"foo"""", entry(tag = "FooBar"))).isFalse()
+    }
+
+    @Test
+    fun `should treat a level as a minimum`() {
+        expectThat(matches("level:W", entry(level = LogLevel.WARN))).isTrue()
+        expectThat(matches("level:W", entry(level = LogLevel.ERROR))).isTrue()
+        expectThat(matches("level:W", entry(level = LogLevel.INFO))).isFalse()
+    }
+
+    @Test
+    fun `should resolve every spelling of a level`() {
+        listOf("level:E", "level:e", "level:err", "level:ERROR").forEach { query ->
+            expectThat(matches(query, entry(level = LogLevel.ERROR))).isTrue()
+            expectThat(matches(query, entry(level = LogLevel.WARN))).isFalse()
+        }
+    }
+
+    @Test
+    fun `should compare pid numerically`() {
+        expectThat(matches("pid:1234", entry(pid = 1234))).isTrue()
+        expectThat(matches("pid:1234", entry(pid = 9999))).isFalse()
+    }
+
+    @Test
+    fun `should match nothing for a non-numeric pid`() {
+        expectThat(matches("pid:abc", entry(pid = 1234))).isFalse()
+    }
+
+    @Test
+    fun `should scope package mine to this process`() {
+        expectThat(matches("package:mine", entry(pid = 1234))).isTrue()
+        expectThat(matches("package:mine", entry(pid = 9999))).isFalse()
+    }
+
+    @Test
+    fun `should match a package literal only against this app`() {
+        expectThat(matches("package:flixclusive", entry(pid = 1234))).isTrue()
+        expectThat(matches("package:com.other", entry(pid = 1234))).isFalse()
+        expectThat(matches("package:flixclusive", entry(pid = 9999))).isFalse()
+    }
+
+    @Test
+    fun `should invert a negated term`() {
+        expectThat(matches("-tag:foo", entry(tag = "Foo"))).isFalse()
+        expectThat(matches("-tag:foo", entry(tag = "Bar"))).isTrue()
+        expectThat(matches("-level:W", entry(level = LogLevel.INFO))).isTrue()
+    }
+
+    @Test
+    fun `should require every term to match`() {
+        val target = entry(tag = "Player", level = LogLevel.ERROR, message = "stream failed")
+
+        expectThat(matches("tag:Player level:E stream", target)).isTrue()
+        expectThat(matches("tag:Player level:E missing", target)).isFalse()
+    }
+
+    @Test
+    fun `should let a bare term hit either the tag or the message`() {
+        expectThat(matches("Player", entry(tag = "Player", message = "body"))).isTrue()
+        expectThat(matches("body", entry(tag = "Player", message = "body"))).isTrue()
+        expectThat(matches("absent", entry(tag = "Player", message = "body"))).isFalse()
+    }
+
+    @Test
+    fun `should match a regex term`() {
+        expectThat(matches("tag~:^Pl.*er$", entry(tag = "Player"))).isTrue()
+        expectThat(matches("tag~:^Pl.*er$", entry(tag = "Provider"))).isFalse()
+    }
+
+    @Test
+    fun `should match everything for an empty query`() {
+        expectThat(matches("", entry())).isTrue()
+    }
+}

--- a/feature/mobile/settings/src/test/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogFilterParserTest.kt
+++ b/feature/mobile/settings/src/test/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogFilterParserTest.kt
@@ -1,0 +1,119 @@
+package com.flixclusive.feature.mobile.settings.screen.system.logcat
+
+import org.junit.Test
+import strikt.api.expectThat
+import strikt.assertions.hasSize
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotNull
+import strikt.assertions.isNull
+
+class LogFilterParserTest {
+    private fun parse(query: String) = LogFilterParser.parse(query)
+
+    @Test
+    fun `should treat a bare word as a substring term`() {
+        expectThat(parse("timeout").filter)
+            .isA<LogFilter.Bare>()
+            .get { matcher }
+            .isEqualTo(ValueMatcher.Substring("timeout"))
+    }
+
+    @Test
+    fun `should parse an unquoted key as a substring field`() {
+        expectThat(parse("tag:Foo").filter)
+            .isA<LogFilter.Field>()
+            .and {
+                get { key }.isEqualTo(FilterKey.TAG)
+                get { matcher }.isEqualTo(ValueMatcher.Substring("Foo"))
+            }
+    }
+
+    @Test
+    fun `should parse a quoted value as exact and keep its spaces`() {
+        expectThat(parse("""tag:"My Tag"""").filter)
+            .isA<LogFilter.Field>()
+            .get { matcher }
+            .isEqualTo(ValueMatcher.Exact("My Tag"))
+    }
+
+    @Test
+    fun `should parse the regex operator`() {
+        expectThat(parse("tag~:F.*").filter)
+            .isA<LogFilter.Field>()
+            .get { matcher }
+            .isA<ValueMatcher.Pattern>()
+    }
+
+    @Test
+    fun `should parse negation`() {
+        expectThat(parse("-tag:Foo").filter)
+            .isA<LogFilter.Not>()
+            .get { term }
+            .isA<LogFilter.Field>()
+            .get { key }
+            .isEqualTo(FilterKey.TAG)
+    }
+
+    @Test
+    fun `should and multiple terms in order`() {
+        expectThat(parse("tag:Foo level:E timeout").filter)
+            .isA<LogFilter.And>()
+            .get { terms }
+            .hasSize(3)
+    }
+
+    @Test
+    fun `should alias msg to message`() {
+        expectThat(parse("msg:body").filter)
+            .isA<LogFilter.Field>()
+            .get { key }
+            .isEqualTo(FilterKey.MESSAGE)
+    }
+
+    @Test
+    fun `should keep an unknown key as a bare term`() {
+        expectThat(parse("foo:bar").filter)
+            .isA<LogFilter.Bare>()
+            .get { matcher }
+            .isEqualTo(ValueMatcher.Substring("foo:bar"))
+    }
+
+    @Test
+    fun `should match everything for an empty query`() {
+        expectThat(parse("").filter).isA<LogFilter.MatchAll>()
+        expectThat(parse("   ").filter).isA<LogFilter.MatchAll>()
+    }
+
+    @Test
+    fun `should report an unterminated quote without dropping the term`() {
+        val parsed = parse("""tag:"My Tag""")
+
+        expectThat(parsed.error).isNotNull()
+        expectThat(parsed.filter).isA<LogFilter.Field>().get { key }.isEqualTo(FilterKey.TAG)
+    }
+
+    @Test
+    fun `should degrade an invalid regex to a substring term`() {
+        val parsed = parse("msg~:[")
+
+        expectThat(parsed.error).isNotNull()
+        expectThat(parsed.filter)
+            .isA<LogFilter.Field>()
+            .get { matcher }
+            .isEqualTo(ValueMatcher.Substring("["))
+    }
+
+    @Test
+    fun `should unescape a quote inside a quoted value`() {
+        expectThat(parse("""msg:"say \"hi\""""").filter)
+            .isA<LogFilter.Field>()
+            .get { matcher }
+            .isEqualTo(ValueMatcher.Exact("""say "hi""""))
+    }
+
+    @Test
+    fun `should report no error for a well formed query`() {
+        expectThat(parse("package:mine level:W -tag:OkHttp").error).isNull()
+    }
+}

--- a/feature/mobile/settings/src/test/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogcatParserTest.kt
+++ b/feature/mobile/settings/src/test/kotlin/com/flixclusive/feature/mobile/settings/screen/system/logcat/LogcatParserTest.kt
@@ -1,0 +1,138 @@
+package com.flixclusive.feature.mobile.settings.screen.system.logcat
+
+import org.junit.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
+import strikt.assertions.isNotNull
+import strikt.assertions.isNull
+import strikt.assertions.isTrue
+import strikt.assertions.startsWith
+
+class LogcatParserTest {
+    private fun parse(
+        raw: String,
+        id: Long = 0L,
+        previous: LogEntry? = null,
+    ) = LogcatParser.parse(raw = raw, id = id, previous = previous)
+
+    @Test
+    fun `should parse every field of a canonical threadtime line`() {
+        val entry = parse("06-14 09:12:33.123  1234  1256 D MyTag  : hello world")
+
+        expectThat(entry).isNotNull().and {
+            get { date }.isEqualTo("06-14")
+            get { time }.isEqualTo("09:12:33.123")
+            get { pid }.isEqualTo(1234)
+            get { tid }.isEqualTo(1256)
+            get { level }.isEqualTo(LogLevel.DEBUG)
+            get { tag }.isEqualTo("MyTag")
+            get { message }.isEqualTo("hello world")
+            get { isContinuation }.isFalse()
+        }
+    }
+
+    @Test
+    fun `should parse a year-prefixed line`() {
+        val entry = parse("2026-06-14 09:12:33.123  1234  1256 I Tag: body")
+
+        expectThat(entry).isNotNull().and {
+            get { date }.isEqualTo("06-14")
+            get { level }.isEqualTo(LogLevel.INFO)
+            get { message }.isEqualTo("body")
+        }
+    }
+
+    @Test
+    fun `should parse a tag containing spaces`() {
+        val entry = parse("06-14 09:12:33.123  1234  1256 W My Tag: body")
+
+        expectThat(entry).isNotNull().get { tag }.isEqualTo("My Tag")
+    }
+
+    @Test
+    fun `should keep colons inside the message`() {
+        val entry = parse("06-14 09:12:33.123  1234  1256 E Tag: host:8080 failed: reset")
+
+        expectThat(entry).isNotNull().get { message }.isEqualTo("host:8080 failed: reset")
+    }
+
+    @Test
+    fun `should map every level letter`() {
+        LogLevel.entries.forEach { level ->
+            val entry = parse("06-14 09:12:33.123  1  2 ${level.letter} Tag: body")
+
+            expectThat(entry).isNotNull().get { this.level }.isEqualTo(level)
+        }
+    }
+
+    @Test
+    fun `should reject an unknown level letter`() {
+        expectThat(parse("06-14 09:12:33.123  1  2 X Tag: body")).isNull()
+    }
+
+    @Test
+    fun `should drop buffer dividers`() {
+        expectThat(parse("--------- beginning of crash")).isNull()
+    }
+
+    @Test
+    fun `should drop blank lines`() {
+        expectThat(parse("   ")).isNull()
+    }
+
+    @Test
+    fun `should emit a continuation inheriting the previous header`() {
+        val previous = parse("06-14 09:12:33.123  1234  1256 E Crash: java.lang.IllegalStateException")
+        val continuation = parse(
+            raw = "\tat com.flixclusive.Foo.bar(Foo.kt:42)",
+            id = 1L,
+            previous = previous,
+        )
+
+        expectThat(continuation).isNotNull().and {
+            get { id }.isEqualTo(1L)
+            get { pid }.isEqualTo(1234)
+            get { tid }.isEqualTo(1256)
+            get { level }.isEqualTo(LogLevel.ERROR)
+            get { tag }.isEqualTo("Crash")
+            get { message }.isEqualTo("at com.flixclusive.Foo.bar(Foo.kt:42)")
+            get { isContinuation }.isTrue()
+            get { messageStart }.isEqualTo(previous!!.messageStart)
+        }
+    }
+
+    @Test
+    fun `should drop a headerless line when there is no previous entry`() {
+        expectThat(parse("\tat com.flixclusive.Foo.bar(Foo.kt:42)")).isNull()
+    }
+
+    @Test
+    fun `should truncate a message beyond the line limit`() {
+        val long = "x".repeat(LogcatParser.MAX_LINE_CHARS + 500)
+        val entry = parse("06-14 09:12:33.123  1  2 D Tag: $long")
+
+        expectThat(entry)
+            .isNotNull()
+            .get { message }
+            .get { length }
+            .isEqualTo(LogcatParser.MAX_LINE_CHARS + 1)
+    }
+
+    @Test
+    fun `should point messageStart at the first message character`() {
+        val entry = parse("06-14 09:12:33.123  1234  1256 D MyTag: hello")!!
+
+        expectThat(entry.text.substring(entry.messageStart)).isEqualTo("hello")
+        expectThat(entry.text).startsWith("09:12:33.123  1234-1256  D  MyTag")
+    }
+
+    @Test
+    fun `should align a continuation under the message column`() {
+        val previous = parse("06-14 09:12:33.123  1234  1256 E Crash: header")
+        val continuation = parse(raw = "frame", id = 1L, previous = previous)!!
+
+        expectThat(continuation.text.substring(continuation.messageStart)).isEqualTo("frame")
+        expectThat(continuation.text.take(continuation.messageStart).isBlank()).isTrue()
+    }
+}


### PR DESCRIPTION
## Description

There is currently no way to see the app's runtime logs from inside the app — `CrashActivity`
only shows a single stack trace after the process has already died — so a user hitting a
provider, playback, or network failure has nothing to inspect and nothing to attach to a bug
report. This adds an Android-Studio-style Logcat viewer.

- Adds a Logcat viewer under **Settings → System → Debug** that streams the app's own log buffer live.
- `LogcatDataSource` runs `logcat -v threadtime` inside a `channelFlow`:
    - The body parks on a cancellable `pump.join()` so `finally { process.destroy() }` actually runs — `readLine()` is uninterruptible, and a plain `flow {}` would leak the process and its reader thread.
    - Lines are batched on a 120–250 ms window driven by `reader.ready()`, capping list recompositions at ~8/s regardless of log rate.
- `LogFilterParser` implements AS-style conditional queries — `tag:`/`msg:`/`package:`/`level:`/`pid:`/`tid:`, `-` negation, quoted exact, `~:` regex, implicit AND — defaulting to `package:mine`. It never throws; an invalid regex degrades to a substring term.
- `LogcatTweakViewModel` holds a 5 000-entry ring buffer, filters on `appDispatchers.default`, and shares with `WhileSubscribed(5_000)`, so the logcat process dies 5 s after the screen leaves but survives rotation.
- Rows render monospaced and unwrapped; every row shares one `ScrollState` and one measured width so they pan in unison without extent jitter.
- Adds `share`/`more_vert` drawables, screen strings, and the Destinations + `MobileAppNavigator` wiring.

Fixes # N/A

## Checklist:

- [x] I have followed the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for all my commits.
